### PR TITLE
Add admin dashboard and pricing utility

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import NotFound from "@/pages/not-found";
 import Landing from "@/pages/landing";
 import Quote from "@/pages/quote";
 import PrivacyPage from "@/pages/legal/privacy";
+import Admin from "@/pages/admin";
 
 function Router() {
   return (
@@ -14,6 +15,7 @@ function Router() {
       <Route path="/" component={Landing} />
       <Route path="/quote" component={Quote} />
       <Route path="/legal/privacy" component={PrivacyPage} />
+      <Route path="/admin" component={Admin} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/lib/pricing.ts
+++ b/client/src/lib/pricing.ts
@@ -1,0 +1,68 @@
+export interface VehicleInfo {
+  year: number;
+  make: string;
+  model: string;
+  odometer: number;
+}
+
+export interface CoverageInfo {
+  plan: "powertrain" | "gold" | "platinum";
+  deductible: number;
+}
+
+export interface LocationInfo {
+  zip: string;
+  state: string;
+}
+
+export interface QuoteEstimate {
+  plan: CoverageInfo["plan"];
+  deductible: number;
+  termMonths: number;
+  priceMonthly: number; // in cents
+  priceTotal: number; // in cents
+}
+
+/**
+ * Basic quote estimation utility used by both client and server.
+ * The algorithm is intentionally simple and should be replaced with
+ * real pricing logic in production.
+ */
+export function calculateQuote(
+  vehicle: VehicleInfo,
+  coverage: CoverageInfo,
+  _location: LocationInfo
+): QuoteEstimate {
+  const currentYear = new Date().getFullYear();
+  const age = Math.max(0, currentYear - vehicle.year);
+
+  // Base monthly price by coverage plan in dollars
+  let basePrice = 0;
+  switch (coverage.plan) {
+    case "powertrain":
+      basePrice = 60;
+      break;
+    case "gold":
+      basePrice = 80;
+      break;
+    case "platinum":
+      basePrice = 100;
+      break;
+  }
+
+  // Adjust based on vehicle age and mileage
+  basePrice += age * 2; // +$2 per year of age
+  basePrice += vehicle.odometer / 10000; // +$1 per 10k miles
+
+  const priceMonthly = Math.round(basePrice * 100); // convert to cents
+  const termMonths = 36;
+  const priceTotal = priceMonthly * termMonths;
+
+  return {
+    plan: coverage.plan,
+    deductible: coverage.deductible,
+    termMonths,
+    priceMonthly,
+    priceTotal,
+  };
+}

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState, FormEvent } from "react";
+import { apiRequest } from "@/lib/queryClient";
+
+interface Lead {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+interface Vehicle {
+  year: number;
+  make: string;
+  model: string;
+}
+
+interface Quote {
+  plan: string;
+  priceMonthly: number; // cents
+}
+
+interface LeadMeta {
+  tags: string[];
+  priority: "low" | "medium" | "high";
+}
+
+interface LeadWithDetails extends Lead {
+  vehicle?: Vehicle | null;
+  quotes: Quote[];
+  meta: LeadMeta;
+}
+
+export default function Admin() {
+  const [leads, setLeads] = useState<LeadWithDetails[]>([]);
+
+  const fetchLeads = async () => {
+    const res = await apiRequest("GET", "/api/leads");
+    const data = await res.json();
+    const leadsData: Lead[] = data.data;
+
+    const detailed = await Promise.all(
+      leadsData.map(async (lead) => {
+        const [vehicleRes, quotesRes, metaRes] = await Promise.all([
+          apiRequest("GET", `/api/leads/${lead.id}/vehicle`).then((r) => r.json()).catch(() => ({ data: null })),
+          apiRequest("GET", `/api/leads/${lead.id}/quotes`).then((r) => r.json()).catch(() => ({ data: [] })),
+          apiRequest("GET", `/api/leads/${lead.id}/meta`).then((r) => r.json()).catch(() => ({ data: { tags: [], priority: "low" } })),
+        ]);
+        return {
+          ...lead,
+          vehicle: vehicleRes.data,
+          quotes: quotesRes.data,
+          meta: metaRes.data,
+        } as LeadWithDetails;
+      })
+    );
+
+    setLeads(detailed);
+  };
+
+  useEffect(() => {
+    fetchLeads();
+  }, []);
+
+  const handleCoverage = async (e: FormEvent<HTMLFormElement>, id: string) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    await apiRequest("POST", `/api/leads/${id}/coverage`, {
+      plan: formData.get("plan"),
+      deductible: Number(formData.get("deductible")),
+      termMonths: Number(formData.get("termMonths")),
+      priceMonthly: Number(formData.get("priceMonthly")),
+    });
+    await fetchLeads();
+  };
+
+  const handleMeta = async (e: FormEvent<HTMLFormElement>, id: string) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    await apiRequest("POST", `/api/leads/${id}/meta`, {
+      tags: formData.get("tags"),
+      priority: formData.get("priority"),
+    });
+    await fetchLeads();
+  };
+
+  const customers = leads.filter((l) => l.quotes.length > 0);
+
+  return (
+    <div className="p-4 space-y-8">
+      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Reporting & Analytics</h2>
+        <div className="border p-4 rounded">
+          <p>Total Leads: {leads.length}</p>
+          <p>Customers: {customers.length}</p>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Lead Management</h2>
+        {leads.map((lead) => (
+          <div key={lead.id} className="border p-4 rounded mb-4">
+            <h3 className="font-semibold">
+              {lead.firstName ?? ""} {lead.lastName ?? ""}
+            </h3>
+            <p>Email: {lead.email ?? ""}</p>
+            <p>Phone: {lead.phone ?? ""}</p>
+            {lead.vehicle && (
+              <p>
+                Vehicle: {lead.vehicle.year} {lead.vehicle.make} {lead.vehicle.model}
+              </p>
+            )}
+            <form onSubmit={(e) => handleCoverage(e, lead.id)} className="mt-2 space-x-2">
+              <select name="plan" defaultValue="powertrain" className="border p-1">
+                <option value="powertrain">powertrain</option>
+                <option value="gold">gold</option>
+                <option value="platinum">platinum</option>
+              </select>
+              <input type="number" name="deductible" defaultValue={100} className="border p-1 w-24" />
+              <input type="number" step="0.01" name="priceMonthly" defaultValue={100} className="border p-1 w-32" />
+              <input type="hidden" name="termMonths" value="36" />
+              <button type="submit" className="border px-2 py-1">Assign Coverage</button>
+            </form>
+            <form onSubmit={(e) => handleMeta(e, lead.id)} className="mt-2 space-x-2">
+              <input
+                type="text"
+                name="tags"
+                defaultValue={lead.meta.tags.join(", ")}
+                className="border p-1"
+              />
+              <select name="priority" defaultValue={lead.meta.priority} className="border p-1">
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+              </select>
+              <button type="submit" className="border px-2 py-1">Save Meta</button>
+            </form>
+            <button className="border px-2 py-1 mt-2" disabled>
+              Send Quote (todo)
+            </button>
+          </div>
+        ))}
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Customer Management</h2>
+        {customers.map((c) => (
+          <div key={c.id} className="border p-4 rounded mb-4">
+            <h3 className="font-semibold">
+              {c.firstName ?? ""} {c.lastName ?? ""}
+            </h3>
+            {c.quotes[0] && (
+              <>
+                <p>Plan: {c.quotes[0].plan}</p>
+                <p>
+                  Monthly Price: ${((c.quotes[0].priceMonthly ?? 0) / 100).toFixed(2)}
+                </p>
+              </>
+            )}
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -58,6 +58,8 @@ export const quotes = pgTable("quotes", {
   plan: planTypeEnum("plan").notNull(),
   deductible: integer("deductible").notNull(),
   termMonths: integer("term_months").default(36),
+  priceMonthly: integer("price_monthly").notNull(),
+  priceTotal: integer("price_total").notNull(),
   fees: integer("fees").default(0),
   taxes: integer("taxes").default(0),
   status: quoteStatusEnum("status").default('draft'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["shared/**/*", "server/**/*"],
+  "include": ["shared/**/*", "server/**/*", "client/src/lib/pricing.ts"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts", "server/replitAuth.ts"],
   "compilerOptions": {
     "incremental": true,


### PR DESCRIPTION
## Summary
- provide shared `calculateQuote` pricing utility
- expose admin dashboard via React page and API endpoints
- extend quote schema with pricing fields

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d2f9bda7083308a5a69d8acaa15dd