### PR TITLE
Enhance admin dashboard with navigation, search, and filters

### DIFF
--- a/client/src/components/admin-nav.tsx
+++ b/client/src/components/admin-nav.tsx
@@ -1,0 +1,58 @@
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface AdminNavProps {
+  search: string;
+  setSearch: (val: string) => void;
+  priority: string;
+  setPriority: (val: string) => void;
+}
+
+export default function AdminNav({
+  search,
+  setSearch,
+  priority,
+  setPriority,
+}: AdminNavProps) {
+  return (
+    <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between p-4 border-b bg-white">
+      <nav className="flex items-center gap-4">
+        <a href="#analytics" className="font-semibold text-primary">
+          Dashboard
+        </a>
+        <a href="#leads" className="text-gray-600 hover:text-primary">
+          Leads
+        </a>
+        <a href="#customers" className="text-gray-600 hover:text-primary">
+          Customers
+        </a>
+      </nav>
+      <div className="flex items-center gap-2 w-full sm:w-auto">
+        <Input
+          placeholder="Search leads..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full sm:w-64"
+        />
+        <Select value={priority} onValueChange={setPriority}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="All priorities" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">All</SelectItem>
+            <SelectItem value="low">Low</SelectItem>
+            <SelectItem value="medium">Medium</SelectItem>
+            <SelectItem value="high">High</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </header>
+  );
+}
+

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, FormEvent } from "react";
 import { apiRequest } from "@/lib/queryClient";
+import AdminNav from "@/components/admin-nav";
 
 interface Lead {
   id: string;
@@ -33,6 +34,8 @@ interface LeadWithDetails extends Lead {
 
 export default function Admin() {
   const [leads, setLeads] = useState<LeadWithDetails[]>([]);
+  const [search, setSearch] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState("");
 
   const fetchLeads = async () => {
     const res = await apiRequest("GET", "/api/leads");
@@ -86,84 +89,167 @@ export default function Admin() {
     await fetchLeads();
   };
 
-  const customers = leads.filter((l) => l.quotes.length > 0);
+  const filteredLeads = leads.filter((lead) => {
+    const term = search.toLowerCase();
+    const matchesSearch =
+      term === "" ||
+      `${lead.firstName ?? ""} ${lead.lastName ?? ""}`
+        .toLowerCase()
+        .includes(term) ||
+      (lead.email ?? "").toLowerCase().includes(term);
+    const matchesPriority =
+      priorityFilter === "" || lead.meta.priority === priorityFilter;
+    return matchesSearch && matchesPriority;
+  });
+
+  const customers = filteredLeads.filter((l) => l.quotes.length > 0);
 
   return (
-    <div className="p-4 space-y-8">
-      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Reporting & Analytics</h2>
-        <div className="border p-4 rounded">
-          <p>Total Leads: {leads.length}</p>
-          <p>Customers: {customers.length}</p>
+    <div className="min-h-screen flex bg-gray-50">
+      <aside className="hidden md:block w-64 bg-white border-r">
+        <div className="p-6">
+          <h2 className="text-lg font-semibold text-gray-900">CRM</h2>
+          <nav className="mt-6 space-y-2">
+            <a href="#analytics" className="block px-2 py-1 rounded hover:bg-gray-100">
+              Dashboard
+            </a>
+            <a href="#leads" className="block px-2 py-1 rounded hover:bg-gray-100">
+              Leads
+            </a>
+            <a href="#customers" className="block px-2 py-1 rounded hover:bg-gray-100">
+              Customers
+            </a>
+          </nav>
         </div>
-      </section>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Lead Management</h2>
-        {leads.map((lead) => (
-          <div key={lead.id} className="border p-4 rounded mb-4">
-            <h3 className="font-semibold">
-              {lead.firstName ?? ""} {lead.lastName ?? ""}
-            </h3>
-            <p>Email: {lead.email ?? ""}</p>
-            <p>Phone: {lead.phone ?? ""}</p>
-            {lead.vehicle && (
-              <p>
-                Vehicle: {lead.vehicle.year} {lead.vehicle.make} {lead.vehicle.model}
-              </p>
-            )}
-            <form onSubmit={(e) => handleCoverage(e, lead.id)} className="mt-2 space-x-2">
-              <select name="plan" defaultValue="powertrain" className="border p-1">
-                <option value="powertrain">powertrain</option>
-                <option value="gold">gold</option>
-                <option value="platinum">platinum</option>
-              </select>
-              <input type="number" name="deductible" defaultValue={100} className="border p-1 w-24" />
-              <input type="number" step="0.01" name="priceMonthly" defaultValue={100} className="border p-1 w-32" />
-              <input type="hidden" name="termMonths" value="36" />
-              <button type="submit" className="border px-2 py-1">Assign Coverage</button>
-            </form>
-            <form onSubmit={(e) => handleMeta(e, lead.id)} className="mt-2 space-x-2">
-              <input
-                type="text"
-                name="tags"
-                defaultValue={lead.meta.tags.join(", ")}
-                className="border p-1"
-              />
-              <select name="priority" defaultValue={lead.meta.priority} className="border p-1">
-                <option value="low">low</option>
-                <option value="medium">medium</option>
-                <option value="high">high</option>
-              </select>
-              <button type="submit" className="border px-2 py-1">Save Meta</button>
-            </form>
-            <button className="border px-2 py-1 mt-2" disabled>
-              Send Quote (todo)
-            </button>
-          </div>
-        ))}
-      </section>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Customer Management</h2>
-        {customers.map((c) => (
-          <div key={c.id} className="border p-4 rounded mb-4">
-            <h3 className="font-semibold">
-              {c.firstName ?? ""} {c.lastName ?? ""}
-            </h3>
-            {c.quotes[0] && (
-              <>
-                <p>Plan: {c.quotes[0].plan}</p>
-                <p>
-                  Monthly Price: ${((c.quotes[0].priceMonthly ?? 0) / 100).toFixed(2)}
+      </aside>
+      <div className="flex-1 flex flex-col">
+        <AdminNav
+          search={search}
+          setSearch={setSearch}
+          priority={priorityFilter}
+          setPriority={setPriorityFilter}
+        />
+        <main className="p-4 space-y-8">
+          <section id="analytics">
+            <h2 className="text-xl font-semibold mb-2">Reporting & Analytics</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div className="bg-white rounded shadow p-4">
+                <p className="text-sm text-gray-500">Total Leads</p>
+                <p className="text-2xl font-bold">{leads.length}</p>
+              </div>
+              <div className="bg-white rounded shadow p-4">
+                <p className="text-sm text-gray-500">Customers</p>
+                <p className="text-2xl font-bold">{customers.length}</p>
+              </div>
+              <div className="bg-white rounded shadow p-4">
+                <p className="text-sm text-gray-500">Conversion Rate</p>
+                <p className="text-2xl font-bold">
+                  {leads.length > 0
+                    ? `${((customers.length / leads.length) * 100).toFixed(1)}%`
+                    : "0%"}
                 </p>
-              </>
+              </div>
+            </div>
+          </section>
+
+          <section id="leads">
+            <h2 className="text-xl font-semibold mb-2">Lead Management</h2>
+            {filteredLeads.map((lead) => (
+              <div key={lead.id} className="bg-white border rounded p-4 mb-4 shadow-sm">
+                <h3 className="font-semibold">
+                  {lead.firstName ?? ""} {lead.lastName ?? ""}
+                </h3>
+                <p>Email: {lead.email ?? ""}</p>
+                <p>Phone: {lead.phone ?? ""}</p>
+                {lead.vehicle && (
+                  <p>
+                    Vehicle: {lead.vehicle.year} {lead.vehicle.make} {lead.vehicle.model}
+                  </p>
+                )}
+                <form onSubmit={(e) => handleCoverage(e, lead.id)} className="mt-2 flex flex-wrap gap-2">
+                  <select
+                    name="plan"
+                    defaultValue="powertrain"
+                    className="border p-1 rounded"
+                  >
+                    <option value="powertrain">powertrain</option>
+                    <option value="gold">gold</option>
+                    <option value="platinum">platinum</option>
+                  </select>
+                  <input
+                    type="number"
+                    name="deductible"
+                    defaultValue={100}
+                    className="border p-1 w-24 rounded"
+                  />
+                  <input
+                    type="number"
+                    step="0.01"
+                    name="priceMonthly"
+                    defaultValue={100}
+                    className="border p-1 w-32 rounded"
+                  />
+                  <input type="hidden" name="termMonths" value="36" />
+                  <button
+                    type="submit"
+                    className="border px-2 py-1 rounded bg-primary text-white"
+                  >
+                    Assign Coverage
+                  </button>
+                </form>
+                <form onSubmit={(e) => handleMeta(e, lead.id)} className="mt-2 flex flex-wrap gap-2">
+                  <input
+                    type="text"
+                    name="tags"
+                    defaultValue={lead.meta.tags.join(", ")}
+                    className="border p-1 rounded"
+                  />
+                  <select
+                    name="priority"
+                    defaultValue={lead.meta.priority}
+                    className="border p-1 rounded"
+                  >
+                    <option value="low">low</option>
+                    <option value="medium">medium</option>
+                    <option value="high">high</option>
+                  </select>
+                  <button
+                    type="submit"
+                    className="border px-2 py-1 rounded bg-secondary text-white"
+                  >
+                    Save Meta
+                  </button>
+                </form>
+              </div>
+            ))}
+            {filteredLeads.length === 0 && (
+              <p className="text-gray-500">No leads found.</p>
             )}
-          </div>
-        ))}
-      </section>
+          </section>
+
+          <section id="customers">
+            <h2 className="text-xl font-semibold mb-2">Customer Management</h2>
+            {customers.map((c) => (
+              <div key={c.id} className="bg-white border rounded p-4 mb-4 shadow-sm">
+                <h3 className="font-semibold">
+                  {c.firstName ?? ""} {c.lastName ?? ""}
+                </h3>
+                {c.quotes[0] && (
+                  <>
+                    <p>Plan: {c.quotes[0].plan}</p>
+                    <p>
+                      Monthly Price: ${((c.quotes[0].priceMonthly ?? 0) / 100).toFixed(2)}
+                    </p>
+                  </>
+                )}
+              </div>
+            ))}
+            {customers.length === 0 && (
+              <p className="text-gray-500">No customers found.</p>
+            )}
+          </section>
+        </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add dedicated admin navigation bar with search and priority filters
- Redesign admin dashboard with sidebar layout and analytics cards
- Allow filtering of leads and customers in a more structured view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d3233dfa8833090e102a7e98a7e6a