### PR TITLE
Remove pricing information from plans and quotes

### DIFF
--- a/client/src/components/quote-modal.tsx
+++ b/client/src/components/quote-modal.tsx
@@ -434,17 +434,17 @@ export default function QuoteModal({ isOpen, onClose }: QuoteModalProps) {
                   >
                     <div className="flex flex-col items-center p-4 border rounded-lg cursor-pointer hover:bg-gray-50">
                       <RadioGroupItem value="100" id="deductible-100" className="mb-2" />
-                      <Label htmlFor="deductible-100" className="font-semibold">$100</Label>
+                      <Label htmlFor="deductible-100" className="font-semibold">Low Deductible</Label>
                       <span className="text-sm text-gray-500">Higher premium</span>
                     </div>
                     <div className="flex flex-col items-center p-4 border rounded-lg cursor-pointer hover:bg-gray-50">
                       <RadioGroupItem value="250" id="deductible-250" className="mb-2" />
-                      <Label htmlFor="deductible-250" className="font-semibold">$250</Label>
+                      <Label htmlFor="deductible-250" className="font-semibold">Standard Deductible</Label>
                       <span className="text-sm text-gray-500">Balanced</span>
                     </div>
                     <div className="flex flex-col items-center p-4 border rounded-lg cursor-pointer hover:bg-gray-50">
                       <RadioGroupItem value="500" id="deductible-500" className="mb-2" />
-                      <Label htmlFor="deductible-500" className="font-semibold">$500</Label>
+                      <Label htmlFor="deductible-500" className="font-semibold">High Deductible</Label>
                       <span className="text-sm text-gray-500">Lower premium</span>
                     </div>
                   </RadioGroup>
@@ -463,7 +463,7 @@ export default function QuoteModal({ isOpen, onClose }: QuoteModalProps) {
                     </div>
                     <div className="flex items-center p-3 border rounded-lg cursor-pointer hover:bg-gray-50">
                       <RadioGroupItem value="full" id="full" />
-                      <Label htmlFor="full" className="ml-2">Paid in Full (Save 10%)</Label>
+                      <Label htmlFor="full" className="ml-2">Paid in Full (Save more)</Label>
                     </div>
                   </RadioGroup>
                 </div>

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -237,9 +237,6 @@ export default function Admin() {
                 {c.quotes[0] && (
                   <>
                     <p>Plan: {c.quotes[0].plan}</p>
-                    <p>
-                      Monthly Price: ${((c.quotes[0].priceMonthly ?? 0) / 100).toFixed(2)}
-                    </p>
                   </>
                 )}
               </div>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -125,7 +125,7 @@ export default function Landing() {
               <CardContent className="p-8">
                 <div className="text-center mb-6">
                   <h3 className="text-2xl font-bold mb-2">Powertrain</h3>
-                  <div className="text-4xl font-bold text-primary mb-2">$79<span className="text-lg text-gray-500">/mo</span></div>
+                  <div className="text-4xl font-bold text-primary mb-2">Call for pricing</div>
                   <p className="text-gray-600">Essential engine protection</p>
                 </div>
                 <ul className="space-y-4 mb-8">
@@ -135,7 +135,7 @@ export default function Landing() {
                   </li>
                   <li className="flex items-center">
                     <Check className="w-5 h-5 text-accent mr-3" />
-                    <span>24/7 roadside assistance</span>
+                    <span>Around-the-clock roadside assistance</span>
                   </li>
                   <li className="flex items-center">
                     <Check className="w-5 h-5 text-accent mr-3" />
@@ -160,7 +160,7 @@ export default function Landing() {
               <CardContent className="p-8">
                 <div className="text-center mb-6">
                   <h3 className="text-2xl font-bold mb-2">Gold</h3>
-                  <div className="text-4xl font-bold text-primary mb-2">$129<span className="text-lg text-gray-500">/mo</span></div>
+                  <div className="text-4xl font-bold text-primary mb-2">Call for pricing</div>
                   <p className="text-gray-600">Comprehensive protection</p>
                 </div>
                 <ul className="space-y-4 mb-8">
@@ -196,7 +196,7 @@ export default function Landing() {
               <CardContent className="p-8">
                 <div className="text-center mb-6">
                   <h3 className="text-2xl font-bold mb-2">Platinum</h3>
-                  <div className="text-4xl font-bold text-primary mb-2">$199<span className="text-lg text-gray-500">/mo</span></div>
+                  <div className="text-4xl font-bold text-primary mb-2">Call for pricing</div>
                   <p className="text-gray-600">Maximum coverage</p>
                 </div>
                 <ul className="space-y-4 mb-8">


### PR DESCRIPTION
## Summary
- Replace numerical plan prices with "Call for pricing" on the landing page and avoid numeric labels like "24/7".
- Remove monthly price display from the admin customer's view.
- Update quote modal labels to describe deductible and payment options without dollar amounts.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d33f6872c8330ad3c054ef6e9e948