### PR TITLE
Fix pg Pool import for ESM compatibility

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -1,9 +1,11 @@
 import { Pool as NeonPool, neonConfig } from "@neondatabase/serverless";
 import { drizzle as neonDrizzle } from "drizzle-orm/neon-serverless";
 import ws from "ws";
-import { Pool as PgPool } from "pg";
+import pg from "pg";
 import { drizzle as pgDrizzle } from "drizzle-orm/node-postgres";
 import * as schema from "@shared/schema";
+
+const PgPool = pg.Pool;
 
 const connectionString = process.env.DATABASE_URL;
 


### PR DESCRIPTION
## Summary
- switch to default import for `pg` and use `pg.Pool`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d362935a883309ee5837106a54785