### PR TITLE
fix: use non-empty value for admin priority filter

### DIFF
--- a/client/src/components/admin-nav.tsx
+++ b/client/src/components/admin-nav.tsx
@@ -45,7 +45,7 @@ export default function AdminNav({
             <SelectValue placeholder="All priorities" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">All</SelectItem>
+            <SelectItem value="all">All priorities</SelectItem>
             <SelectItem value="low">Low</SelectItem>
             <SelectItem value="medium">Medium</SelectItem>
             <SelectItem value="high">High</SelectItem>

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -35,7 +35,7 @@ interface LeadWithDetails extends Lead {
 export default function Admin() {
   const [leads, setLeads] = useState<LeadWithDetails[]>([]);
   const [search, setSearch] = useState("");
-  const [priorityFilter, setPriorityFilter] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState("all");
 
   const fetchLeads = async () => {
     const res = await apiRequest("GET", "/api/leads");
@@ -98,7 +98,7 @@ export default function Admin() {
         .includes(term) ||
       (lead.email ?? "").toLowerCase().includes(term);
     const matchesPriority =
-      priorityFilter === "" || lead.meta.priority === priorityFilter;
+      priorityFilter === "all" || lead.meta.priority === priorityFilter;
     return matchesSearch && matchesPriority;
   });
 


### PR DESCRIPTION
## Summary
- avoid empty value in priority filter select
- treat `all` as no priority filter

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d378c1a6c833096fa528db57b5ca0