### PR TITLE
Fix vehicle validation on lead submission

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -71,7 +71,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post('/api/leads', async (req, res) => {
     try {
       const leadData = insertLeadSchema.parse(req.body.lead);
-      const vehicleData = insertVehicleSchema.parse(req.body.vehicle);
+      // The client doesn't include a leadId when submitting vehicle info.
+      // We validate the vehicle data without the leadId and add it after
+      // creating the lead.
+      const vehicleData = insertVehicleSchema
+        .omit({ leadId: true })
+        .parse(req.body.vehicle);
       
       // Create lead
       const lead = await storage.createLead({


### PR DESCRIPTION
## Summary
- allow vehicle data to be submitted without a leadId and assign it after lead creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d39de6bd48330aecbbc44726b68e9