### PR TITLE
Add policy conversion and lead notes management

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2,12 +2,18 @@ import {
   leads,
   vehicles,
   quotes,
+  notes,
+  policies,
   type Lead,
   type InsertLead,
   type Vehicle,
   type InsertVehicle,
   type Quote,
   type InsertQuote,
+  type Note,
+  type InsertNote,
+  type Policy,
+  type InsertPolicy,
 } from "@shared/schema";
 import { db } from "./db";
 import { eq, desc } from "drizzle-orm";
@@ -26,6 +32,14 @@ export interface IStorage {
   // Quote operations
   getQuotesByLeadId(leadId: string): Promise<Quote[]>;
   createQuote(quote: InsertQuote): Promise<Quote>;
+
+  // Note operations
+  getNotesByLeadId(leadId: string): Promise<Note[]>;
+  createNote(note: InsertNote): Promise<Note>;
+
+  // Policy operations
+  createPolicy(policy: InsertPolicy): Promise<Policy>;
+  getPolicies(): Promise<Policy[]>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -65,6 +79,32 @@ export class DatabaseStorage implements IStorage {
   async createQuote(quoteData: InsertQuote): Promise<Quote> {
     const [quote] = await db.insert(quotes).values(quoteData).returning();
     return quote;
+  }
+
+  // Note operations
+  async getNotesByLeadId(leadId: string): Promise<Note[]> {
+    const result = await db
+      .select()
+      .from(notes)
+      .where(eq(notes.leadId, leadId))
+      .orderBy(desc(notes.createdAt));
+    return result;
+  }
+
+  async createNote(noteData: InsertNote): Promise<Note> {
+    const [note] = await db.insert(notes).values(noteData).returning();
+    return note;
+  }
+
+  // Policy operations
+  async createPolicy(policyData: InsertPolicy): Promise<Policy> {
+    const [policy] = await db.insert(policies).values(policyData).returning();
+    return policy;
+  }
+
+  async getPolicies(): Promise<Policy[]> {
+    const result = await db.select().from(policies).orderBy(desc(policies.createdAt));
+    return result;
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -68,6 +68,28 @@ export const quotes = pgTable("quotes", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+export const notes = pgTable("notes", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  leadId: varchar("lead_id").references(() => leads.id, { onDelete: 'cascade' }).notNull(),
+  content: text("content").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const policies = pgTable("policies", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  leadId: varchar("lead_id").references(() => leads.id, { onDelete: 'set null' }).notNull(),
+  package: varchar("package"),
+  expirationMiles: integer("expiration_miles"),
+  expirationDate: timestamp("expiration_date"),
+  deductible: integer("deductible"),
+  totalPremium: integer("total_premium"),
+  downPayment: integer("down_payment"),
+  policyStartDate: timestamp("policy_start_date"),
+  monthlyPayment: integer("monthly_payment"),
+  totalPayments: integer("total_payments"),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Relations
 export const leadsRelations = relations(leads, ({ one, many }) => ({
   vehicle: one(vehicles),
@@ -88,6 +110,20 @@ export const quotesRelations = relations(quotes, ({ one }) => ({
   }),
 }));
 
+export const notesRelations = relations(notes, ({ one }) => ({
+  lead: one(leads, {
+    fields: [notes.leadId],
+    references: [leads.id],
+  }),
+}));
+
+export const policiesRelations = relations(policies, ({ one }) => ({
+  lead: one(leads, {
+    fields: [policies.leadId],
+    references: [leads.id],
+  }),
+}));
+
 // Schemas for validation
 export const insertLeadSchema = createInsertSchema(leads).omit({
   id: true,
@@ -104,6 +140,16 @@ export const insertQuoteSchema = createInsertSchema(quotes).omit({
   createdAt: true,
 });
 
+export const insertNoteSchema = createInsertSchema(notes).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertPolicySchema = createInsertSchema(policies).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Types
 export type Lead = typeof leads.$inferSelect;
 export type InsertLead = z.infer<typeof insertLeadSchema>;
@@ -111,3 +157,7 @@ export type Vehicle = typeof vehicles.$inferSelect;
 export type InsertVehicle = z.infer<typeof insertVehicleSchema>;
 export type Quote = typeof quotes.$inferSelect;
 export type InsertQuote = z.infer<typeof insertQuoteSchema>;
+export type Note = typeof notes.$inferSelect;
+export type InsertNote = z.infer<typeof insertNoteSchema>;
+export type Policy = typeof policies.$inferSelect;
+export type InsertPolicy = z.infer<typeof insertPolicySchema>;


### PR DESCRIPTION
## Summary
- create database tables for notes and policies
- expose admin API endpoints for lead details, notes, and policy conversion
- extend admin lead detail UI with policy form, vehicle and notes toggles, and convert button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d41cdbb3483308c43953cb5ec199e