### PR TITLE
Add admin navigation and claims listing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,8 @@ import PrivacyPage from "@/pages/legal/privacy";
 import AdminDashboard from "@/pages/admin/dashboard";
 import AdminLeads from "@/pages/admin/leads";
 import AdminLeadDetail from "@/pages/admin/leads/[id]";
+import AdminPolicies from "@/pages/admin/policies";
+import AdminClaims from "@/pages/admin/claims";
 import About from "@/pages/about";
 import FAQ from "@/pages/faq";
 
@@ -23,6 +25,8 @@ function Router() {
       <Route path="/legal/privacy" component={PrivacyPage} />
       <Route path="/admin/leads/:id" component={AdminLeadDetail} />
       <Route path="/admin/leads" component={AdminLeads} />
+      <Route path="/admin/policies" component={AdminPolicies} />
+      <Route path="/admin/claims" component={AdminClaims} />
       <Route path="/admin" component={AdminDashboard} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/components/admin-nav.tsx
+++ b/client/src/components/admin-nav.tsx
@@ -1,0 +1,30 @@
+import { Link } from "wouter";
+
+export default function AdminNav() {
+  const username = "admin";
+  return (
+    <nav className="bg-white border-b">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16 items-center">
+          <div className="flex space-x-6">
+            <Link href="/admin/leads" className="text-gray-700 hover:text-primary">
+              Leads
+            </Link>
+            <Link href="/admin/policies" className="text-gray-700 hover:text-primary">
+              Policies
+            </Link>
+            <Link href="/admin/claims" className="text-gray-700 hover:text-primary">
+              Claims
+            </Link>
+          </div>
+          <div className="text-sm text-gray-600">
+            Logged in as: {username}{" "}
+            <a href="/" className="ml-2 hover:underline">
+              Logout
+            </a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -1,0 +1,73 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import AdminNav from "@/components/admin-nav";
+
+const getAuthHeaders = () => ({
+  Authorization: 'Basic ' + btoa('admin:password'),
+});
+
+export default function AdminClaims() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['/api/admin/claims'],
+    queryFn: () =>
+      fetch('/api/admin/claims', { headers: getAuthHeaders() }).then(res => {
+        if (!res.ok) throw new Error('Failed to fetch claims');
+        return res.json();
+      })
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  const claims = data?.data || [];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Claims</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>ID</TableHead>
+                    <TableHead>Policy ID</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {claims.map((claim: any) => (
+                    <TableRow key={claim.id}>
+                      <TableCell>{claim.id}</TableCell>
+                      <TableCell>{claim.policyId}</TableCell>
+                      <TableCell className="capitalize">{claim.status.replace(/_/g, ' ')}</TableCell>
+                      <TableCell>{new Date(claim.createdAt).toLocaleDateString()}</TableCell>
+                    </TableRow>
+                  ))}
+                  {claims.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center py-4 text-gray-500">
+                        No claims found
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Users, FileText, Target, TrendingUp, Activity, Calendar } from "lucide-react";
 import { Link } from "wouter";
+import AdminNav from "@/components/admin-nav";
 
 // Helper function to set basic auth header
 const getAuthHeaders = () => ({
@@ -46,6 +47,7 @@ export default function AdminDashboard() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <AdminNav />
       {/* Header */}
       <div className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/client/src/pages/admin/leads.tsx
+++ b/client/src/pages/admin/leads.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Users, Search, Filter, ArrowUpDown, Eye, Phone, Mail } from "lucide-react";
 import { Link } from "wouter";
 import { useToast } from "@/hooks/use-toast";
+import AdminNav from "@/components/admin-nav";
 
 // Helper function to set basic auth header
 const getAuthHeaders = () => ({
@@ -98,6 +99,7 @@ export default function AdminLeads() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <AdminNav />
       {/* Header */}
       <div className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -12,6 +12,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { ArrowLeft, User, Car, Activity, Phone, Mail, DollarSign } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import AdminNav from "@/components/admin-nav";
 
 // Helper function to set basic auth header
 const getAuthHeaders = () => ({
@@ -198,6 +199,7 @@ export default function AdminLeadDetail() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <AdminNav />
       {/* Header */}
       <div className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/client/src/pages/admin/policies.tsx
+++ b/client/src/pages/admin/policies.tsx
@@ -1,0 +1,73 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import AdminNav from "@/components/admin-nav";
+
+const getAuthHeaders = () => ({
+  Authorization: 'Basic ' + btoa('admin:password'),
+});
+
+export default function AdminPolicies() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['/api/admin/policies'],
+    queryFn: () =>
+      fetch('/api/admin/policies', { headers: getAuthHeaders() }).then(res => {
+        if (!res.ok) throw new Error('Failed to fetch policies');
+        return res.json();
+      })
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  const policies = data?.data || [];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Policies</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>ID</TableHead>
+                    <TableHead>Lead ID</TableHead>
+                    <TableHead>Package</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {policies.map((policy: any) => (
+                    <TableRow key={policy.id}>
+                      <TableCell>{policy.id}</TableCell>
+                      <TableCell>{policy.leadId}</TableCell>
+                      <TableCell>{policy.package || 'N/A'}</TableCell>
+                      <TableCell>{new Date(policy.createdAt).toLocaleDateString()}</TableCell>
+                    </TableRow>
+                  ))}
+                  {policies.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center py-4 text-gray-500">
+                        No policies found
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -351,6 +351,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Admin: list policies
+  app.get('/api/admin/policies', basicAuth, async (_req, res) => {
+    try {
+      const policies = await storage.getPolicies();
+      res.json({ data: policies, message: 'Policies retrieved successfully' });
+    } catch (error) {
+      console.error('Error fetching policies:', error);
+      res.status(500).json({ message: 'Failed to fetch policies' });
+    }
+  });
+
+  // Admin: list claims
+  app.get('/api/admin/claims', basicAuth, async (_req, res) => {
+    try {
+      const claims = await storage.getClaims();
+      res.json({ data: claims, message: 'Claims retrieved successfully' });
+    } catch (error) {
+      console.error('Error fetching claims:', error);
+      res.status(500).json({ message: 'Failed to fetch claims' });
+    }
+  });
+
   const httpServer = createServer(app);
   return httpServer;
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -4,6 +4,7 @@ import {
   quotes,
   notes,
   policies,
+  claims,
   type Lead,
   type InsertLead,
   type Vehicle,
@@ -14,6 +15,8 @@ import {
   type InsertNote,
   type Policy,
   type InsertPolicy,
+  type Claim,
+  type InsertClaim,
 } from "@shared/schema";
 import { db } from "./db";
 import { eq, desc } from "drizzle-orm";
@@ -40,6 +43,10 @@ export interface IStorage {
   // Policy operations
   createPolicy(policy: InsertPolicy): Promise<Policy>;
   getPolicies(): Promise<Policy[]>;
+
+  // Claim operations
+  createClaim(claim: InsertClaim): Promise<Claim>;
+  getClaims(): Promise<Claim[]>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -104,6 +111,17 @@ export class DatabaseStorage implements IStorage {
 
   async getPolicies(): Promise<Policy[]> {
     const result = await db.select().from(policies).orderBy(desc(policies.createdAt));
+    return result;
+  }
+
+  // Claim operations
+  async createClaim(claimData: InsertClaim): Promise<Claim> {
+    const [claim] = await db.insert(claims).values(claimData).returning();
+    return claim;
+  }
+
+  async getClaims(): Promise<Claim[]> {
+    const result = await db.select().from(claims).orderBy(desc(claims.createdAt));
     return result;
   }
 }


### PR DESCRIPTION
## Summary
- add shared admin navigation with links to leads, policies and claims
- add policies and claims listing pages
- extend backend and schema with claim model and list endpoints

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d45e4c62883309d04efe83ddb6ec9