### PR TITLE
Add send quote and convert actions to lead detail

### DIFF
--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -224,6 +224,26 @@ export default function AdminLeadDetail() {
               </div>
             </div>
             <div className="flex items-center space-x-2">
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+              >
+                <a
+                  href={`https://americancarprotect.com/vsp/send_quote_email_api.php?api_key=Kzy!MaaBCha4&leadid=${id}&uid=45`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Send Quote
+                </a>
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => convertLeadMutation.mutate(policyForm)}
+                disabled={convertLeadMutation.isPending}
+              >
+                {convertLeadMutation.isPending ? 'Converting...' : 'Convert To Policy'}
+              </Button>
               <Badge variant={
                 lead.stage === 'new' ? 'default' :
                 lead.stage === 'contacted' ? 'secondary' :

--- a/client/src/pages/lead/[id].tsx
+++ b/client/src/pages/lead/[id].tsx
@@ -1,0 +1,1 @@
+export { default } from "../admin/leads/[id]";


### PR DESCRIPTION
## Summary
- add quick actions for sending quotes and converting to policy on lead detail page
- expose lead detail page at `/lead/:id`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e1441fd2c8330b12e1567374b69ee