### PR TITLE
Refactor lead status and UI

### DIFF
--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -143,14 +143,7 @@ export default function AdminDashboard() {
                       </div>
                     </div>
                     <div className="flex items-center space-x-2">
-                      <Badge variant={
-                        item.lead.stage === 'new' ? 'default' :
-                        item.lead.stage === 'contacted' ? 'secondary' :
-                        item.lead.stage === 'quoted' ? 'destructive' :
-                        'outline'
-                      }>
-                        {item.lead.stage}
-                      </Badge>
+                      <Badge variant="outline">{item.lead.status}</Badge>
                       <Button size="sm" variant="outline" asChild>
                         <Link href={`/admin/leads/${item.lead.id}`}>View</Link>
                       </Button>
@@ -166,25 +159,25 @@ export default function AdminDashboard() {
             </CardContent>
           </Card>
 
-          {/* Lead Stage Breakdown */}
+          {/* Lead Status Breakdown */}
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center">
                 <TrendingUp className="h-5 w-5 mr-2" />
                 Lead Pipeline
               </CardTitle>
-              <CardDescription>Breakdown of leads by stage</CardDescription>
+              <CardDescription>Breakdown of leads by status</CardDescription>
             </CardHeader>
             <CardContent>
               <div className="space-y-3">
-                {statsData.leadsByStage?.map((stage: any) => (
-                  <div key={stage.stage} className="flex items-center justify-between">
-                    <span className="capitalize">{stage.stage.replace('-', ' ')}</span>
-                    <Badge variant="outline">{stage.count}</Badge>
+                {statsData.leadsByStatus?.map((status: any) => (
+                  <div key={status.status} className="flex items-center justify-between">
+                    <span className="capitalize">{status.status.replace('-', ' ')}</span>
+                    <Badge variant="outline">{status.count}</Badge>
                   </div>
                 )) || (
                   <div className="text-center py-8 text-gray-500">
-                    No stage data available
+                    No status data available
                   </div>
                 )}
               </div>

--- a/client/src/pages/admin/leads.tsx
+++ b/client/src/pages/admin/leads.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Users, Search, Filter, ArrowUpDown, Eye, Phone, Mail } from "lucide-react";
+import { Users, Search, Filter, Eye, Phone, Mail } from "lucide-react";
 import { Link } from "wouter";
 import { useToast } from "@/hooks/use-toast";
 import AdminNav from "@/components/admin-nav";
@@ -19,7 +19,7 @@ const getAuthHeaders = () => ({
 
 export default function AdminLeads() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [stageFilter, setStageFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
@@ -62,30 +62,26 @@ export default function AdminLeads() {
 
   const leads = leadsData?.data || [];
 
-  // Filter leads based on search and stage
+  // Filter leads based on search and status
   const filteredLeads = leads.filter((item: any) => {
     const lead = item.lead;
-    const matchesSearch = !searchTerm || 
-      `${lead.firstName} ${lead.lastName}`.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    const matchesSearch =
+      !searchTerm ||
+      `${lead.firstName} ${lead.lastName}`
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase()) ||
       lead.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       lead.phone?.includes(searchTerm);
-    
-    const matchesStage = stageFilter === "all" || lead.stage === stageFilter;
-    
-    return matchesSearch && matchesStage;
+
+    const matchesStatus = statusFilter === "all" || lead.status === statusFilter;
+
+    return matchesSearch && matchesStatus;
   });
 
-  const handleStageChange = (leadId: string, newStage: string) => {
+  const handleStatusChange = (leadId: string, newStatus: string) => {
     updateLeadMutation.mutate({
       id: leadId,
-      updates: { stage: newStage }
-    });
-  };
-
-  const handlePriorityChange = (leadId: string, newPriority: string) => {
-    updateLeadMutation.mutate({
-      id: leadId,
-      updates: { priority: newPriority }
+      updates: { status: newStatus },
     });
   };
 
@@ -143,18 +139,23 @@ export default function AdminLeads() {
                   className="pl-10"
                 />
               </div>
-              <Select value={stageFilter} onValueChange={setStageFilter}>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
                 <SelectTrigger>
-                  <SelectValue placeholder="Filter by stage" />
+                  <SelectValue placeholder="Filter by status" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">All Stages</SelectItem>
+                  <SelectItem value="all">All Statuses</SelectItem>
                   <SelectItem value="new">New</SelectItem>
-                  <SelectItem value="contacted">Contacted</SelectItem>
-                  <SelectItem value="qualified">Qualified</SelectItem>
                   <SelectItem value="quoted">Quoted</SelectItem>
-                  <SelectItem value="closed-won">Closed Won</SelectItem>
-                  <SelectItem value="closed-lost">Closed Lost</SelectItem>
+                  <SelectItem value="callback">Callback</SelectItem>
+                  <SelectItem value="left-message">Left Message</SelectItem>
+                  <SelectItem value="no-contact">No Contact</SelectItem>
+                  <SelectItem value="wrong-number">Wrong Number</SelectItem>
+                  <SelectItem value="fake-lead">Fake Lead</SelectItem>
+                  <SelectItem value="not-interested">Not Interested</SelectItem>
+                  <SelectItem value="duplicate-lead">Duplicate Lead</SelectItem>
+                  <SelectItem value="dnc">DNC</SelectItem>
+                  <SelectItem value="sold">Sold</SelectItem>
                 </SelectContent>
               </Select>
               <div className="text-sm text-gray-600 flex items-center">
@@ -178,8 +179,7 @@ export default function AdminLeads() {
                     <TableHead>Customer</TableHead>
                     <TableHead>Vehicle</TableHead>
                     <TableHead>Contact</TableHead>
-                    <TableHead>Stage</TableHead>
-                    <TableHead>Priority</TableHead>
+                    <TableHead>Status</TableHead>
                     <TableHead>Quotes</TableHead>
                     <TableHead>Created</TableHead>
                     <TableHead>Actions</TableHead>
@@ -226,35 +226,24 @@ export default function AdminLeads() {
                         </TableCell>
                         <TableCell>
                           <Select
-                            value={lead.stage}
-                            onValueChange={(value) => handleStageChange(lead.id, value)}
+                            value={lead.status}
+                            onValueChange={(value) => handleStatusChange(lead.id, value)}
                           >
-                            <SelectTrigger className="w-32">
+                            <SelectTrigger className="w-40">
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
                               <SelectItem value="new">New</SelectItem>
-                              <SelectItem value="contacted">Contacted</SelectItem>
-                              <SelectItem value="qualified">Qualified</SelectItem>
                               <SelectItem value="quoted">Quoted</SelectItem>
-                              <SelectItem value="closed-won">Closed Won</SelectItem>
-                              <SelectItem value="closed-lost">Closed Lost</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </TableCell>
-                        <TableCell>
-                          <Select
-                            value={lead.priority}
-                            onValueChange={(value) => handlePriorityChange(lead.id, value)}
-                          >
-                            <SelectTrigger className="w-24">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="low">Low</SelectItem>
-                              <SelectItem value="medium">Medium</SelectItem>
-                              <SelectItem value="high">High</SelectItem>
-                              <SelectItem value="urgent">Urgent</SelectItem>
+                              <SelectItem value="callback">Callback</SelectItem>
+                              <SelectItem value="left-message">Left Message</SelectItem>
+                              <SelectItem value="no-contact">No Contact</SelectItem>
+                              <SelectItem value="wrong-number">Wrong Number</SelectItem>
+                              <SelectItem value="fake-lead">Fake Lead</SelectItem>
+                              <SelectItem value="not-interested">Not Interested</SelectItem>
+                              <SelectItem value="duplicate-lead">Duplicate Lead</SelectItem>
+                              <SelectItem value="dnc">DNC</SelectItem>
+                              <SelectItem value="sold">Sold</SelectItem>
                             </SelectContent>
                           </Select>
                         </TableCell>
@@ -281,7 +270,7 @@ export default function AdminLeads() {
                   })}
                   {filteredLeads.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={8} className="text-center py-8 text-gray-500">
+                      <TableCell colSpan={7} className="text-center py-8 text-gray-500">
                         No leads found matching your criteria
                       </TableCell>
                     </TableRow>

--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -244,21 +244,27 @@ export default function AdminLeadDetail() {
               >
                 {convertLeadMutation.isPending ? 'Converting...' : 'Convert To Policy'}
               </Button>
-              <Badge variant={
-                lead.stage === 'new' ? 'default' :
-                lead.stage === 'contacted' ? 'secondary' :
-                lead.stage === 'quoted' ? 'destructive' :
-                'outline'
-              }>
-                {lead.stage}
-              </Badge>
-              <Badge variant={
-                lead.priority === 'urgent' ? 'destructive' :
-                lead.priority === 'high' ? 'default' :
-                'outline'
-              }>
-                {lead.priority} priority
-              </Badge>
+              <Select
+                value={lead.status}
+                onValueChange={(value) => updateLeadMutation.mutate({ status: value })}
+              >
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue placeholder="--- Please Select ---" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="new">New</SelectItem>
+                  <SelectItem value="quoted">Quoted</SelectItem>
+                  <SelectItem value="callback">Callback</SelectItem>
+                  <SelectItem value="left-message">Left Message</SelectItem>
+                  <SelectItem value="no-contact">No Contact</SelectItem>
+                  <SelectItem value="wrong-number">Wrong Number</SelectItem>
+                  <SelectItem value="fake-lead">Fake Lead</SelectItem>
+                  <SelectItem value="not-interested">Not Interested</SelectItem>
+                  <SelectItem value="duplicate-lead">Duplicate Lead</SelectItem>
+                  <SelectItem value="dnc">DNC</SelectItem>
+                  <SelectItem value="sold">Sold</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
         </div>
@@ -274,10 +280,10 @@ export default function AdminLeadDetail() {
 
           <TabsContent value="overview" className="space-y-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <Accordion type="single" collapsible>
+              <Accordion type="single" collapsible defaultValue="lead">
                 <AccordionItem value="lead">
                   <AccordionTrigger className="flex items-center">
-                    <User className="h-5 w-5 mr-2" />
+                    <span className="mr-2"><User className="h-5 w-5" /></span>
                     Lead Information
                   </AccordionTrigger>
                   <AccordionContent>
@@ -329,7 +335,7 @@ export default function AdminLeadDetail() {
                 </AccordionItem>
               </Accordion>
 
-              <Accordion type="multiple" className="space-y-4">
+              <Accordion type="multiple" className="space-y-4" defaultValue={["policy", "vehicle", "notes"]}>
                 <AccordionItem value="policy">
                   <AccordionTrigger>Policy Information</AccordionTrigger>
                   <AccordionContent>
@@ -337,11 +343,19 @@ export default function AdminLeadDetail() {
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div>
                           <Label>Package</Label>
-                          <Input
+                          <Select
                             value={policyForm.package}
-                            onChange={(e) => setPolicyForm({ ...policyForm, package: e.target.value })}
-                            placeholder="--- Please Select ---"
-                          />
+                            onValueChange={(value) => setPolicyForm({ ...policyForm, package: value })}
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="--- Please Select ---" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="basic">Basic</SelectItem>
+                              <SelectItem value="gold">Gold</SelectItem>
+                              <SelectItem value="platinum">Platinum</SelectItem>
+                            </SelectContent>
+                          </Select>
                         </div>
                         <div>
                           <Label>Expiration Miles</Label>
@@ -490,51 +504,6 @@ export default function AdminLeadDetail() {
               </Accordion>
             </div>
 
-            {/* Lead Management */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Lead Management</CardTitle>
-                <CardDescription>Update lead status</CardDescription>
-              </CardHeader>
-              <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label>Stage</Label>
-                  <Select
-                    value={lead.stage}
-                    onValueChange={(value) => updateLeadMutation.mutate({ stage: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="new">New</SelectItem>
-                      <SelectItem value="contacted">Contacted</SelectItem>
-                      <SelectItem value="qualified">Qualified</SelectItem>
-                      <SelectItem value="quoted">Quoted</SelectItem>
-                      <SelectItem value="closed-won">Closed Won</SelectItem>
-                      <SelectItem value="closed-lost">Closed Lost</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label>Priority</Label>
-                  <Select
-                    value={lead.priority}
-                    onValueChange={(value) => updateLeadMutation.mutate({ priority: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="low">Low</SelectItem>
-                      <SelectItem value="medium">Medium</SelectItem>
-                      <SelectItem value="high">High</SelectItem>
-                      <SelectItem value="urgent">Urgent</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </CardContent>
-            </Card>
           </TabsContent>
 
           <TabsContent value="quotes" className="space-y-6">


### PR DESCRIPTION
## Summary
- auto-expand lead detail accordions and keep user icon upright
- replace priority/stage with status dropdown and update lead lists and dashboard
- support Basic/Gold/Platinum policy packages

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e1a09e3bc8330aa2335912d5ca032