### PR TITLE
Add public claims submission page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import AdminPolicies from "@/pages/admin/policies";
 import AdminClaims from "@/pages/admin/claims";
 import About from "@/pages/about";
 import FAQ from "@/pages/faq";
+import Claims from "@/pages/claims";
 
 function Router() {
   return (
@@ -22,6 +23,7 @@ function Router() {
       <Route path="/quote" component={Quote} />
       <Route path="/about" component={About} />
       <Route path="/faq" component={FAQ} />
+      <Route path="/claims" component={Claims} />
       <Route path="/legal/privacy" component={PrivacyPage} />
       <Route path="/admin/leads/:id" component={AdminLeadDetail} />
       <Route path="/admin/leads" component={AdminLeads} />

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -35,6 +35,12 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
               >
                 FAQ
               </a>
+              <a
+                href="/claims"
+                className="text-gray-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
+              >
+                Claims
+              </a>
               <Button
                 className="bg-primary text-white hover:bg-secondary"
                 size="sm"

--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -40,8 +40,10 @@ export default function AdminClaims() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>ID</TableHead>
-                    <TableHead>Policy ID</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Phone</TableHead>
+                    <TableHead>Message</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead>Created</TableHead>
                   </TableRow>
@@ -49,15 +51,17 @@ export default function AdminClaims() {
                 <TableBody>
                   {claims.map((claim: any) => (
                     <TableRow key={claim.id}>
-                      <TableCell>{claim.id}</TableCell>
-                      <TableCell>{claim.policyId}</TableCell>
+                      <TableCell>{claim.firstName} {claim.lastName}</TableCell>
+                      <TableCell>{claim.email}</TableCell>
+                      <TableCell>{claim.phone}</TableCell>
+                      <TableCell className="max-w-xs truncate">{claim.message}</TableCell>
                       <TableCell className="capitalize">{claim.status.replace(/_/g, ' ')}</TableCell>
                       <TableCell>{new Date(claim.createdAt).toLocaleDateString()}</TableCell>
                     </TableRow>
                   ))}
                   {claims.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={4} className="text-center py-4 text-gray-500">
+                      <TableCell colSpan={6} className="text-center py-4 text-gray-500">
                         No claims found
                       </TableCell>
                     </TableRow>

--- a/client/src/pages/claims.tsx
+++ b/client/src/pages/claims.tsx
@@ -1,0 +1,182 @@
+import Navigation from "@/components/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Mail, HelpCircle } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+const claimFormSchema = z.object({
+  firstName: z.string().min(1, "Required"),
+  lastName: z.string().min(1, "Required"),
+  email: z.string().email("Invalid email"),
+  phone: z.string().min(1, "Required"),
+  message: z.string().min(1, "Required"),
+});
+
+type ClaimForm = z.infer<typeof claimFormSchema>;
+
+export default function Claims() {
+  const { toast } = useToast();
+  const form = useForm<ClaimForm>({
+    resolver: zodResolver(claimFormSchema),
+    defaultValues: {
+      firstName: "",
+      lastName: "",
+      email: "",
+      phone: "",
+      message: "",
+    },
+  });
+
+  const onSubmit = async (values: ClaimForm) => {
+    try {
+      const res = await fetch('/api/claims', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error('Failed');
+      toast({ title: 'Claim submitted', description: "We'll be in touch soon." });
+      form.reset();
+    } catch (error) {
+      toast({ title: 'Submission failed', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation onGetQuote={() => {}} />
+
+      {/* Hero Section */}
+      <section className="relative">
+        <div className="absolute inset-0">
+          <img
+            src="https://images.unsplash.com/photo-1503376780353-7e6692767b70?auto=format&fit=crop&w=1500&q=80"
+            alt="Road"
+            className="w-full h-64 object-cover"
+          />
+          <div className="absolute inset-0 bg-primary/80" />
+        </div>
+        <div className="relative h-64 flex items-center justify-center">
+          <h1 className="text-4xl font-bold text-white">CLAIMS</h1>
+        </div>
+      </section>
+
+      <div className="max-w-5xl mx-auto px-4 py-12 grid md:grid-cols-2 gap-8">
+        {/* Left Column */}
+        <div className="space-y-6">
+          <div className="flex items-start space-x-4 bg-white p-6 rounded-lg shadow-sm">
+            <div className="bg-primary/10 p-3 rounded-full">
+              <HelpCircle className="w-6 h-6 text-primary" />
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold mb-1">Have a Claim?</h2>
+              <p className="text-gray-600 text-sm">
+                Fill out the form and our team will reach out shortly.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start space-x-4 bg-white p-6 rounded-lg shadow-sm">
+            <div className="bg-primary/10 p-3 rounded-full">
+              <Mail className="w-6 h-6 text-primary" />
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold mb-1">Email Us Directly</h2>
+              <p className="text-gray-600 text-sm">
+                <a href="mailto:claims@bhautoprotect.com" className="text-primary">
+                  claims@bhautoprotect.com
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Right Column */}
+        <Card className="bg-white">
+          <CardContent className="p-6">
+            <h2 className="text-2xl font-bold mb-2">Need Assistance?</h2>
+            <p className="text-gray-600 mb-6">Send us a message and we'll get back to you.</p>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <div className="grid md:grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="firstName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>First Name</FormLabel>
+                        <FormControl>
+                          <Input placeholder="First name" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="lastName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Last Name</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Last name" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <Input type="email" placeholder="you@example.com" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Phone</FormLabel>
+                      <FormControl>
+                        <Input placeholder="(555) 123-4567" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="message"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Message</FormLabel>
+                      <FormControl>
+                        <Textarea rows={4} placeholder="How can we help?" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit" className="w-full">SUBMIT YOUR MESSAGE</Button>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express, RequestHandler } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { z } from "zod";
-import { insertLeadSchema, insertVehicleSchema } from "@shared/schema";
+import { insertLeadSchema, insertVehicleSchema, insertClaimSchema } from "@shared/schema";
 import { calculateQuote } from "../client/src/lib/pricing";
 
 const ADMIN_USER = { username: "admin", password: "password" } as const;
@@ -365,6 +365,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error('Error updating lead:', error);
       res.status(400).json({ message: 'Invalid lead data' });
+    }
+  });
+
+  // Public claim submission endpoint
+  app.post('/api/claims', async (req, res) => {
+    try {
+      const claimData = insertClaimSchema.parse(req.body);
+      const claim = await storage.createClaim(claimData);
+      res.json({ data: claim, message: 'Claim submitted successfully' });
+    } catch (error) {
+      console.error('Error submitting claim:', error);
+      res.status(400).json({ message: 'Invalid claim data' });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -100,12 +100,13 @@ export const policies = pgTable("policies", {
 
 export const claims = pgTable("claims", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  policyId: varchar("policy_id").references(() => policies.id, { onDelete: 'cascade' }).notNull(),
+  policyId: varchar("policy_id").references(() => policies.id, { onDelete: 'cascade' }),
   status: claimStatusEnum("status").default('new'),
-  firstName: varchar("first_name"),
-  lastName: varchar("last_name"),
-  email: varchar("email"),
-  phone: varchar("phone"),
+  firstName: varchar("first_name").notNull(),
+  lastName: varchar("last_name").notNull(),
+  email: varchar("email").notNull(),
+  phone: varchar("phone").notNull(),
+  message: text("message").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
 });
 


### PR DESCRIPTION
## Summary
- add claims submission page with hero section, guidance cards, and required form fields
- wire up claims endpoint and schema to store submissions
- surface claims navigation link and admin listing columns

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e1d8e065c83308883de0a28444bd9