### PR TITLE
feat: expand admin lead management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import PrivacyPage from "@/pages/legal/privacy";
 import AdminDashboard from "@/pages/admin/dashboard";
 import AdminLeads from "@/pages/admin/leads";
 import AdminLeadDetail from "@/pages/admin/leads/[id]";
+import AdminLeadNew from "@/pages/admin/leads/new";
 import AdminPolicies from "@/pages/admin/policies";
 import AdminClaims from "@/pages/admin/claims";
 import About from "@/pages/about";
@@ -23,6 +24,7 @@ function Router() {
       <Route path="/about" component={About} />
       <Route path="/faq" component={FAQ} />
       <Route path="/legal/privacy" component={PrivacyPage} />
+      <Route path="/admin/leads/new" component={AdminLeadNew} />
       <Route path="/admin/leads/:id" component={AdminLeadDetail} />
       <Route path="/admin/leads" component={AdminLeads} />
       <Route path="/admin/policies" component={AdminPolicies} />

--- a/client/src/pages/admin/leads/new.tsx
+++ b/client/src/pages/admin/leads/new.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
+import { useLocation } from "wouter";
+import AdminNav from "@/components/admin-nav";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const getAuthHeaders = () => ({
+  Authorization: 'Basic ' + btoa('admin:password'),
+  'Content-Type': 'application/json',
+});
+
+export default function AdminLeadNew() {
+  const { toast } = useToast();
+  const [, setLocation] = useLocation();
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    state: '',
+    ipState: '',
+    year: '',
+    make: '',
+    model: '',
+    referrer: '',
+  });
+
+  const createLead = useMutation({
+    mutationFn: (data: typeof form) =>
+      fetch('/api/admin/leads', {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({
+          lead: {
+            firstName: data.firstName,
+            lastName: data.lastName,
+            email: data.email,
+            phone: data.phone,
+            state: data.state,
+            consentIP: data.ipState,
+            source: data.referrer,
+          },
+          vehicle: {
+            year: Number(data.year),
+            make: data.make,
+            model: data.model,
+            odometer: 0,
+          },
+        }),
+      }).then(res => {
+        if (!res.ok) throw new Error('Failed to create lead');
+        return res.json();
+      }),
+    onSuccess: () => {
+      toast({ title: 'Success', description: 'Lead created successfully' });
+      setLocation('/admin/leads');
+    },
+    onError: () => {
+      toast({
+        title: 'Error',
+        description: 'Failed to create lead',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const handleChange = (field: string, value: string) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createLead.mutate(form);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Add New Lead</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="firstName">First Name</Label>
+                  <Input id="firstName" value={form.firstName} onChange={e => handleChange('firstName', e.target.value)} />
+                </div>
+                <div>
+                  <Label htmlFor="lastName">Last Name</Label>
+                  <Input id="lastName" value={form.lastName} onChange={e => handleChange('lastName', e.target.value)} />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="email">Email</Label>
+                  <Input id="email" value={form.email} onChange={e => handleChange('email', e.target.value)} />
+                </div>
+                <div>
+                  <Label htmlFor="phone">Phone</Label>
+                  <Input id="phone" value={form.phone} onChange={e => handleChange('phone', e.target.value)} />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="state">Registered State</Label>
+                  <Input id="state" value={form.state} onChange={e => handleChange('state', e.target.value)} />
+                </div>
+                <div>
+                  <Label htmlFor="ipState">IP State</Label>
+                  <Input id="ipState" value={form.ipState} onChange={e => handleChange('ipState', e.target.value)} />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <Label htmlFor="year">Year</Label>
+                  <Input id="year" value={form.year} onChange={e => handleChange('year', e.target.value)} />
+                </div>
+                <div>
+                  <Label htmlFor="make">Make</Label>
+                  <Input id="make" value={form.make} onChange={e => handleChange('make', e.target.value)} />
+                </div>
+                <div>
+                  <Label htmlFor="model">Model</Label>
+                  <Input id="model" value={form.model} onChange={e => handleChange('model', e.target.value)} />
+                </div>
+              </div>
+              <div>
+                <Label htmlFor="referrer">Referrer</Label>
+                <Input id="referrer" value={form.referrer} onChange={e => handleChange('referrer', e.target.value)} />
+              </div>
+              <Button type="submit" disabled={createLead.isLoading}>Create Lead</Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -251,6 +251,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Admin: create lead
+  app.post('/api/admin/leads', basicAuth, async (req, res) => {
+    try {
+      const leadData = insertLeadSchema.parse(req.body.lead);
+      const vehicleData = insertVehicleSchema
+        .omit({ leadId: true })
+        .parse(req.body.vehicle);
+
+      const lead = await storage.createLead(leadData);
+      const vehicle = await storage.createVehicle({
+        ...vehicleData,
+        leadId: lead.id,
+      });
+
+      res.json({
+        data: { lead, vehicle },
+        message: 'Lead created successfully',
+      });
+    } catch (error) {
+      console.error('Error creating lead:', error);
+      res.status(400).json({ message: 'Invalid lead data' });
+    }
+  });
+
   // Admin: list leads with associated data
   app.get('/api/admin/leads', basicAuth, async (_req, res) => {
     try {


### PR DESCRIPTION
## Summary
- make leads table searchable and sortable across all lead and vehicle fields
- show creation time and include link to add new lead
- add admin endpoint and form to manually create leads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e1e9f49648330bd83a1fd251e8e8a