### PR TITLE
feat: add admin claim detail view

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import AdminLeads from "@/pages/admin/leads";
 import AdminLeadDetail from "@/pages/admin/leads/[id]";
 import AdminPolicies from "@/pages/admin/policies";
 import AdminClaims from "@/pages/admin/claims";
+import AdminClaimDetail from "@/pages/admin/claims/[id]";
 import About from "@/pages/about";
 import FAQ from "@/pages/faq";
 import Claims from "@/pages/claims";
@@ -28,6 +29,7 @@ function Router() {
       <Route path="/admin/leads/:id" component={AdminLeadDetail} />
       <Route path="/admin/leads" component={AdminLeads} />
       <Route path="/admin/policies" component={AdminPolicies} />
+      <Route path="/admin/claims/:id" component={AdminClaimDetail} />
       <Route path="/admin/claims" component={AdminClaims} />
       <Route path="/admin" component={AdminDashboard} />
       <Route component={NotFound} />

--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Link } from "wouter";
 import AdminNav from "@/components/admin-nav";
 
 const getAuthHeaders = () => ({
@@ -46,6 +48,7 @@ export default function AdminClaims() {
                     <TableHead>Message</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead>Created</TableHead>
+                    <TableHead>Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -57,11 +60,16 @@ export default function AdminClaims() {
                       <TableCell className="max-w-xs truncate">{claim.message}</TableCell>
                       <TableCell className="capitalize">{claim.status.replace(/_/g, ' ')}</TableCell>
                       <TableCell>{new Date(claim.createdAt).toLocaleDateString()}</TableCell>
+                      <TableCell>
+                        <Button size="sm" variant="outline" asChild>
+                          <Link href={`/admin/claims/${claim.id}`}>View</Link>
+                        </Button>
+                      </TableCell>
                     </TableRow>
                   ))}
                   {claims.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={6} className="text-center py-4 text-gray-500">
+                      <TableCell colSpan={7} className="text-center py-4 text-gray-500">
                         No claims found
                       </TableCell>
                     </TableRow>

--- a/client/src/pages/admin/claims/[id].tsx
+++ b/client/src/pages/admin/claims/[id].tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect } from "react";
+import { useParams, Link } from "wouter";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import AdminNav from "@/components/admin-nav";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+
+const getAuthHeaders = () => ({
+  Authorization: 'Basic ' + btoa('admin:password'),
+  'Content-Type': 'application/json',
+});
+
+export default function AdminClaimDetail() {
+  const { id } = useParams();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ['/api/admin/claims', id],
+    queryFn: () =>
+      fetch(`/api/admin/claims/${id}`, { headers: getAuthHeaders() }).then(res => {
+        if (!res.ok) throw new Error('Failed to fetch claim');
+        return res.json();
+      }),
+    enabled: !!id,
+  });
+
+  const claim = data?.data;
+  const [status, setStatus] = useState('new');
+
+  useEffect(() => {
+    if (claim) setStatus(claim.status);
+  }, [claim]);
+
+  const updateMutation = useMutation({
+    mutationFn: (updates: any) =>
+      fetch(`/api/admin/claims/${id}`, {
+        method: 'PATCH',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(updates),
+      }).then(res => {
+        if (!res.ok) throw new Error('Failed to update claim');
+        return res.json();
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/admin/claims', id] });
+      toast({ title: 'Success', description: 'Claim updated successfully' });
+    },
+    onError: () => {
+      toast({ title: 'Error', description: 'Failed to update claim', variant: 'destructive' });
+    },
+  });
+
+  const handleStatusChange = (value: string) => {
+    setStatus(value);
+    updateMutation.mutate({ status: value });
+  };
+
+  if (isLoading || !claim) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
+        <Button variant="ghost" asChild>
+          <Link href="/admin/claims">&larr; Back to Claims</Link>
+        </Button>
+        <Card>
+          <CardHeader>
+            <CardTitle>Claim Details</CardTitle>
+            <CardDescription>Review claim information and update status</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <Label>Name</Label>
+                <p>{claim.firstName} {claim.lastName}</p>
+              </div>
+              <div>
+                <Label>Email</Label>
+                <p>{claim.email}</p>
+              </div>
+              <div>
+                <Label>Phone</Label>
+                <p>{claim.phone}</p>
+              </div>
+              <div>
+                <Label>Submitted</Label>
+                <p>{new Date(claim.createdAt).toLocaleString()}</p>
+              </div>
+            </div>
+            <div>
+              <Label>Message</Label>
+              <p className="whitespace-pre-line">{claim.message}</p>
+            </div>
+            <div className="max-w-xs">
+              <Label>Status</Label>
+              <Select value={status} onValueChange={handleStatusChange}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="new">New</SelectItem>
+                  <SelectItem value="denied">Denied</SelectItem>
+                  <SelectItem value="awaiting_customer_action">Awaiting Customer Action</SelectItem>
+                  <SelectItem value="awaiting_inspection">Awaiting Inspection</SelectItem>
+                  <SelectItem value="claim_covered_open">Claim Covered Open</SelectItem>
+                  <SelectItem value="claim_covered_closed">Claim Covered Closed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -402,6 +402,44 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Admin: get claim by id
+  app.get('/api/admin/claims/:id', basicAuth, async (req, res) => {
+    try {
+      const claim = await storage.getClaim(req.params.id);
+      if (!claim) {
+        return res.status(404).json({ message: 'Claim not found' });
+      }
+      res.json({ data: claim, message: 'Claim retrieved successfully' });
+    } catch (error) {
+      console.error('Error fetching claim:', error);
+      res.status(500).json({ message: 'Failed to fetch claim' });
+    }
+  });
+
+  // Admin: update claim
+  app.patch('/api/admin/claims/:id', basicAuth, async (req, res) => {
+    const schema = z.object({
+      status: z
+        .enum([
+          'new',
+          'denied',
+          'awaiting_customer_action',
+          'awaiting_inspection',
+          'claim_covered_open',
+          'claim_covered_closed',
+        ])
+        .optional(),
+    });
+    try {
+      const data = schema.parse(req.body);
+      const claim = await storage.updateClaim(req.params.id, data);
+      res.json({ data: claim, message: 'Claim updated successfully' });
+    } catch (error) {
+      console.error('Error updating claim:', error);
+      res.status(400).json({ message: 'Invalid claim data' });
+    }
+  });
+
   const httpServer = createServer(app);
   return httpServer;
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -47,6 +47,8 @@ export interface IStorage {
   // Claim operations
   createClaim(claim: InsertClaim): Promise<Claim>;
   getClaims(): Promise<Claim[]>;
+  getClaim(id: string): Promise<Claim | undefined>;
+  updateClaim(id: string, updates: Partial<Pick<Claim, "status">>): Promise<Claim>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -123,6 +125,20 @@ export class DatabaseStorage implements IStorage {
   async getClaims(): Promise<Claim[]> {
     const result = await db.select().from(claims).orderBy(desc(claims.createdAt));
     return result;
+  }
+
+  async getClaim(id: string): Promise<Claim | undefined> {
+    const [claim] = await db.select().from(claims).where(eq(claims.id, id));
+    return claim;
+  }
+
+  async updateClaim(id: string, updates: Partial<Pick<Claim, "status">>): Promise<Claim> {
+    const [claim] = await db
+      .update(claims)
+      .set(updates)
+      .where(eq(claims.id, id))
+      .returning();
+    return claim;
   }
 }
 


### PR DESCRIPTION
## Summary
- add routes to fetch and update individual claims
- expose claim retrieval/update in storage layer
- add admin claim detail page with status editing and link from list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689e1ff3159883309936215ba8b6635c