### PR TITLE
feat: expand admin claim fields

### DIFF
--- a/client/src/pages/admin/claims/[id].tsx
+++ b/client/src/pages/admin/claims/[id].tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, ChangeEvent, FormEvent } from "react";
 import { useParams, Link } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import AdminNav from "@/components/admin-nav";
@@ -6,6 +6,8 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 
 const getAuthHeaders = () => ({
@@ -28,10 +30,10 @@ export default function AdminClaimDetail() {
   });
 
   const claim = data?.data;
-  const [status, setStatus] = useState('new');
+  const [formData, setFormData] = useState<any>({});
 
   useEffect(() => {
-    if (claim) setStatus(claim.status);
+    if (claim) setFormData(claim);
   }, [claim]);
 
   const updateMutation = useMutation({
@@ -53,9 +55,18 @@ export default function AdminClaimDetail() {
     },
   });
 
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev: any) => ({ ...prev, [name]: value }));
+  };
+
   const handleStatusChange = (value: string) => {
-    setStatus(value);
-    updateMutation.mutate({ status: value });
+    setFormData((prev: any) => ({ ...prev, status: value }));
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    updateMutation.mutate(formData);
   };
 
   if (isLoading || !claim) {
@@ -69,54 +80,123 @@ export default function AdminClaimDetail() {
   return (
     <div className="min-h-screen bg-gray-50">
       <AdminNav />
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
         <Button variant="ghost" asChild>
           <Link href="/admin/claims">&larr; Back to Claims</Link>
         </Button>
         <Card>
           <CardHeader>
-            <CardTitle>Claim Details</CardTitle>
-            <CardDescription>Review claim information and update status</CardDescription>
+            <CardTitle>Update Claim</CardTitle>
+            <CardDescription>Modify claim information</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid md:grid-cols-2 gap-4">
-              <div>
-                <Label>Name</Label>
-                <p>{claim.firstName} {claim.lastName}</p>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label>ID</Label>
+                  <Input value={formData.id} disabled />
+                </div>
+                <div>
+                  <Label>Status</Label>
+                  <Select value={formData.status} onValueChange={handleStatusChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="new">New</SelectItem>
+                      <SelectItem value="denied">Denied</SelectItem>
+                      <SelectItem value="awaiting_customer_action">Awaiting Customer Action</SelectItem>
+                      <SelectItem value="awaiting_inspection">Awaiting Inspection</SelectItem>
+                      <SelectItem value="claim_covered_open">Claim Covered Open</SelectItem>
+                      <SelectItem value="claim_covered_closed">Claim Covered Closed</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label htmlFor="nextEstimate">Next Estimate</Label>
+                  <Input name="nextEstimate" value={formData.nextEstimate || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="nextPayment">Next Payment (from policy)</Label>
+                  <Input name="nextPayment" value={formData.nextPayment || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="firstName">First Name</Label>
+                  <Input name="firstName" value={formData.firstName || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="lastName">Last Name</Label>
+                  <Input name="lastName" value={formData.lastName || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="email">Email</Label>
+                  <Input name="email" value={formData.email || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="phone">Phone</Label>
+                  <Input name="phone" value={formData.phone || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="year">Year</Label>
+                  <Input name="year" value={formData.year || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="make">Make</Label>
+                  <Input name="make" value={formData.make || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="model">Model</Label>
+                  <Input name="model" value={formData.model || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="trim">Trim</Label>
+                  <Input name="trim" value={formData.trim || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="vin">VIN</Label>
+                  <Input name="vin" value={formData.vin || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="serial">Serial</Label>
+                  <Input name="serial" value={formData.serial || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="odometer">Odometer</Label>
+                  <Input name="odometer" value={formData.odometer || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="currentOdometer">Current Odometer Reading</Label>
+                  <Input name="currentOdometer" value={formData.currentOdometer || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="claimReason">Claim Reason</Label>
+                  <Input name="claimReason" value={formData.claimReason || ''} onChange={handleInputChange} />
+                </div>
+                <div>
+                  <Label htmlFor="agentClaimNumber">Agent Claim Number</Label>
+                  <Input name="agentClaimNumber" value={formData.agentClaimNumber || ''} onChange={handleInputChange} />
+                </div>
               </div>
               <div>
-                <Label>Email</Label>
-                <p>{claim.email}</p>
+                <Label htmlFor="message">Claim Notes</Label>
+                <Textarea name="message" value={formData.message || ''} onChange={handleInputChange} />
               </div>
               <div>
-                <Label>Phone</Label>
-                <p>{claim.phone}</p>
+                <Label htmlFor="previousNotes">Previous Notes</Label>
+                <Textarea name="previousNotes" value={formData.previousNotes || ''} onChange={handleInputChange} />
               </div>
-              <div>
-                <Label>Submitted</Label>
-                <p>{new Date(claim.createdAt).toLocaleString()}</p>
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <Label>Created</Label>
+                  <Input value={formData.createdAt ? new Date(formData.createdAt).toLocaleString() : ''} disabled />
+                </div>
+                <div>
+                  <Label>Modified</Label>
+                  <Input value={formData.updatedAt ? new Date(formData.updatedAt).toLocaleString() : ''} disabled />
+                </div>
               </div>
-            </div>
-            <div>
-              <Label>Message</Label>
-              <p className="whitespace-pre-line">{claim.message}</p>
-            </div>
-            <div className="max-w-xs">
-              <Label>Status</Label>
-              <Select value={status} onValueChange={handleStatusChange}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="new">New</SelectItem>
-                  <SelectItem value="denied">Denied</SelectItem>
-                  <SelectItem value="awaiting_customer_action">Awaiting Customer Action</SelectItem>
-                  <SelectItem value="awaiting_inspection">Awaiting Inspection</SelectItem>
-                  <SelectItem value="claim_covered_open">Claim Covered Open</SelectItem>
-                  <SelectItem value="claim_covered_closed">Claim Covered Closed</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+              <Button type="submit">Submit</Button>
+            </form>
           </CardContent>
         </Card>
       </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -454,6 +454,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
           'claim_covered_closed',
         ])
         .optional(),
+      nextEstimate: z.number().optional(),
+      nextPayment: z.number().optional(),
+      firstName: z.string().optional(),
+      lastName: z.string().optional(),
+      email: z.string().email().optional(),
+      phone: z.string().optional(),
+      year: z.number().int().optional(),
+      make: z.string().optional(),
+      model: z.string().optional(),
+      trim: z.string().optional(),
+      vin: z.string().optional(),
+      serial: z.string().optional(),
+      odometer: z.number().int().optional(),
+      currentOdometer: z.number().int().optional(),
+      claimReason: z.string().optional(),
+      agentClaimNumber: z.string().optional(),
+      message: z.string().optional(),
+      previousNotes: z.string().optional(),
     });
     try {
       const data = schema.parse(req.body);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -51,7 +51,7 @@ export interface IStorage {
   createClaim(claim: InsertClaim): Promise<Claim>;
   getClaims(): Promise<Claim[]>;
   getClaim(id: string): Promise<Claim | undefined>;
-  updateClaim(id: string, updates: Partial<Pick<Claim, "status">>): Promise<Claim>;
+  updateClaim(id: string, updates: Partial<Omit<Claim, "id" | "createdAt">>): Promise<Claim>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -126,7 +126,10 @@ export class DatabaseStorage implements IStorage {
 
   // Claim operations
   async createClaim(claimData: InsertClaim): Promise<Claim> {
-    const [claim] = await db.insert(claims).values(claimData).returning();
+    const [claim] = await db
+      .insert(claims)
+      .values({ ...claimData, createdAt: getEasternDate(), updatedAt: getEasternDate() })
+      .returning();
     return claim;
   }
 
@@ -140,10 +143,10 @@ export class DatabaseStorage implements IStorage {
     return claim;
   }
 
-  async updateClaim(id: string, updates: Partial<Pick<Claim, "status">>): Promise<Claim> {
+  async updateClaim(id: string, updates: Partial<Omit<Claim, "id" | "createdAt">>): Promise<Claim> {
     const [claim] = await db
       .update(claims)
-      .set(updates)
+      .set({ ...updates, updatedAt: getEasternDate() })
       .where(eq(claims.id, id))
       .returning();
     return claim;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -102,12 +102,26 @@ export const claims = pgTable("claims", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   policyId: varchar("policy_id").references(() => policies.id, { onDelete: 'cascade' }),
   status: claimStatusEnum("status").default('new'),
+  nextEstimate: decimal("next_estimate"),
+  nextPayment: decimal("next_payment"),
   firstName: varchar("first_name").notNull(),
   lastName: varchar("last_name").notNull(),
   email: varchar("email").notNull(),
   phone: varchar("phone").notNull(),
+  year: integer("year"),
+  make: varchar("make"),
+  model: varchar("model"),
+  trim: varchar("trim"),
+  vin: varchar("vin"),
+  serial: varchar("serial"),
+  odometer: integer("odometer"),
+  currentOdometer: integer("current_odometer"),
+  claimReason: text("claim_reason"),
+  agentClaimNumber: varchar("agent_claim_number"),
   message: text("message").notNull(),
+  previousNotes: text("previous_notes"),
   createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
 });
 
 // Relations
@@ -180,6 +194,7 @@ export const insertPolicySchema = createInsertSchema(policies).omit({
 export const insertClaimSchema = createInsertSchema(claims).omit({
   id: true,
   createdAt: true,
+  updatedAt: true,
 });
 
 // Types


### PR DESCRIPTION
## Summary
- add additional columns to claim schema for vehicle, payment and note details
- allow updating all claim properties via API and storage
- redesign admin claim detail page with inputs for all fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f66da2ec48330babcce9e2d58812c