### PR TITLE
feat: allow admin to create and edit claims

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import AdminLeadNew from "@/pages/admin/leads/new";
 import AdminPolicies from "@/pages/admin/policies";
 import AdminClaims from "@/pages/admin/claims";
 import AdminClaimDetail from "@/pages/admin/claims/[id]";
+import AdminClaimNew from "@/pages/admin/claims/new";
 import About from "@/pages/about";
 import FAQ from "@/pages/faq";
 import Claims from "@/pages/claims";
@@ -31,6 +32,7 @@ function Router() {
       <Route path="/admin/leads/:id" component={AdminLeadDetail} />
       <Route path="/admin/leads" component={AdminLeads} />
       <Route path="/admin/policies" component={AdminPolicies} />
+      <Route path="/admin/claims/new" component={AdminClaimNew} />
       <Route path="/admin/claims/:id" component={AdminClaimDetail} />
       <Route path="/admin/claims" component={AdminClaims} />
       <Route path="/admin" component={AdminDashboard} />

--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -33,6 +33,11 @@ export default function AdminClaims() {
     <div className="min-h-screen bg-gray-50">
       <AdminNav />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-4 flex justify-end">
+          <Button asChild>
+            <Link href="/admin/claims/new">Add Claim</Link>
+          </Button>
+        </div>
         <Card>
           <CardHeader>
             <CardTitle>Claims</CardTitle>

--- a/client/src/pages/admin/claims/new.tsx
+++ b/client/src/pages/admin/claims/new.tsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
+import { useLocation, Link } from "wouter";
+import AdminNav from "@/components/admin-nav";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const getAuthHeaders = () => ({
+  Authorization: 'Basic ' + btoa('admin:password'),
+  'Content-Type': 'application/json',
+});
+
+export default function AdminClaimNew() {
+  const { toast } = useToast();
+  const [, setLocation] = useLocation();
+  const [search, setSearch] = useState("");
+  const [form, setForm] = useState({
+    policyId: "",
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    claimReason: "",
+    message: "",
+  });
+
+  const { data: customers, isLoading } = useQuery({
+    queryKey: ['/api/admin/policy-holders'],
+    queryFn: async () => {
+      const [polRes, leadRes] = await Promise.all([
+        fetch('/api/admin/policies', { headers: getAuthHeaders() }),
+        fetch('/api/admin/leads', { headers: getAuthHeaders() })
+      ]);
+      if (!polRes.ok || !leadRes.ok) throw new Error('Failed to fetch data');
+      const policies = (await polRes.json()).data;
+      const leads = (await leadRes.json()).data;
+      const leadMap = new Map(leads.map((l: any) => [l.lead.id, l.lead]));
+      return policies.map((p: any) => ({ policy: p, lead: leadMap.get(p.leadId) })).filter((c: any) => c.lead);
+    }
+  });
+
+  const filtered = (customers || []).filter((c: any) => {
+    const value = `${c.lead.firstName} ${c.lead.lastName} ${c.lead.email} ${c.lead.phone} ${c.policy.id}`.toLowerCase();
+    return value.includes(search.toLowerCase());
+  });
+
+  const createClaim = useMutation({
+    mutationFn: (data: typeof form) =>
+      fetch('/api/admin/claims', {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(data),
+      }).then(res => {
+        if (!res.ok) throw new Error('Failed to create claim');
+        return res.json();
+      }),
+    onSuccess: (res) => {
+      toast({ title: 'Success', description: 'Claim created successfully' });
+      setLocation(`/admin/claims/${res.data.id}`);
+    },
+    onError: () => {
+      toast({ title: 'Error', description: 'Failed to create claim', variant: 'destructive' });
+    }
+  });
+
+  const handleSelect = (c: any) => {
+    setForm({
+      policyId: c.policy.id,
+      firstName: c.lead.firstName || '',
+      lastName: c.lead.lastName || '',
+      email: c.lead.email || '',
+      phone: c.lead.phone || '',
+      claimReason: '',
+      message: '',
+    });
+  };
+
+  const handleChange = (field: string, value: string) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createClaim.mutate(form);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+        <Button variant="ghost" asChild>
+          <Link href="/admin/claims">&larr; Back to Claims</Link>
+        </Button>
+        <Card>
+          <CardHeader>
+            <CardTitle>Select Policy Holder</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Input
+              placeholder="Search by name, email, phone or policy ID"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="mb-4"
+            />
+            <div className="rounded-md border max-h-64 overflow-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Phone</TableHead>
+                    <TableHead>Policy ID</TableHead>
+                    <TableHead />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((c: any) => (
+                    <TableRow key={c.policy.id}>
+                      <TableCell>{c.lead.firstName} {c.lead.lastName}</TableCell>
+                      <TableCell>{c.lead.email}</TableCell>
+                      <TableCell>{c.lead.phone}</TableCell>
+                      <TableCell>{c.policy.id}</TableCell>
+                      <TableCell>
+                        <Button size="sm" onClick={() => handleSelect(c)}>Select</Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {filtered.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center py-4 text-gray-500">
+                        No results
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+
+        {form.policyId && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Create Claim</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="grid md:grid-cols-2 gap-4">
+                  <div>
+                    <Label>Policy ID</Label>
+                    <Input value={form.policyId} disabled />
+                  </div>
+                  <div>
+                    <Label htmlFor="claimReason">Claim Reason</Label>
+                    <Input id="claimReason" value={form.claimReason} onChange={e => handleChange('claimReason', e.target.value)} />
+                  </div>
+                  <div>
+                    <Label htmlFor="firstName">First Name</Label>
+                    <Input id="firstName" value={form.firstName} onChange={e => handleChange('firstName', e.target.value)} />
+                  </div>
+                  <div>
+                    <Label htmlFor="lastName">Last Name</Label>
+                    <Input id="lastName" value={form.lastName} onChange={e => handleChange('lastName', e.target.value)} />
+                  </div>
+                  <div>
+                    <Label htmlFor="email">Email</Label>
+                    <Input id="email" value={form.email} onChange={e => handleChange('email', e.target.value)} />
+                  </div>
+                  <div>
+                    <Label htmlFor="phone">Phone</Label>
+                    <Input id="phone" value={form.phone} onChange={e => handleChange('phone', e.target.value)} />
+                  </div>
+                </div>
+                <div>
+                  <Label htmlFor="message">Claim Description</Label>
+                  <Textarea id="message" value={form.message} onChange={e => handleChange('message', e.target.value)} />
+                </div>
+                <Button type="submit" disabled={createClaim.isLoading}>Create Claim</Button>
+              </form>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -464,6 +464,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Admin: create claim
+  app.post('/api/admin/claims', basicAuth, async (req, res) => {
+    try {
+      const claimData = insertClaimSchema.parse(req.body);
+      const claim = await storage.createClaim(claimData);
+      res.json({ data: claim, message: 'Claim created successfully' });
+    } catch (error) {
+      console.error('Error creating claim:', error);
+      res.status(400).json({ message: 'Invalid claim data' });
+    }
+  });
+
   // Admin: list claims
   app.get('/api/admin/claims', basicAuth, async (_req, res) => {
     try {
@@ -491,18 +503,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Admin: update claim
   app.patch('/api/admin/claims/:id', basicAuth, async (req, res) => {
-    const schema = z.object({
-      status: z
-        .enum([
-          'new',
-          'denied',
-          'awaiting_customer_action',
-          'awaiting_inspection',
-          'claim_covered_open',
-          'claim_covered_closed',
-        ])
-        .optional(),
-    });
+    const schema = insertClaimSchema.partial();
     try {
       const data = schema.parse(req.body);
       const claim = await storage.updateClaim(req.params.id, data);


### PR DESCRIPTION
## Summary
- add admin UI to create claims for existing policy holders
- wire up route and navigation for new claim creation page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a74f56d830833093f5e2d6b796b747