### PR TITLE
feat: add admin login dialog

### DIFF
--- a/client/src/components/admin-login.tsx
+++ b/client/src/components/admin-login.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { setCredentials, getAuthHeaders, clearCredentials } from "@/lib/auth";
+
+type Props = {
+  onSuccess: () => void;
+};
+
+export default function AdminLogin({ onSuccess }: Props) {
+  const [username, setUsername] = useState("admin");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setCredentials({ username, password });
+
+    // Attempt a simple authenticated request to verify credentials
+    const res = await fetch("/api/admin/stats", { headers: getAuthHeaders() });
+    if (res.ok) {
+      setError("");
+      onSuccess();
+    } else {
+      clearCredentials();
+      setError("Invalid username or password");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-center">Admin Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              placeholder="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <Button type="submit" className="w-full">
+              Login
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,0 +1,34 @@
+// Utility functions for storing and retrieving admin credentials
+// Credentials are stored in localStorage so admin pages can reuse them
+
+export type Credentials = {
+  username: string;
+  password: string;
+};
+
+const STORAGE_KEY = "adminAuth";
+
+export function setCredentials(creds: Credentials): void {
+  // Store credentials as base64 to reuse in Authorization header
+  const token = btoa(`${creds.username}:${creds.password}`);
+  localStorage.setItem(STORAGE_KEY, token);
+}
+
+export function clearCredentials(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function getAuthToken(): string | null {
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+export function getAuthHeaders(): Record<string, string> {
+  const token = getAuthToken();
+  if (!token) return {};
+  return { Authorization: `Basic ${token}` };
+}
+
+export function hasCredentials(): boolean {
+  return getAuthToken() !== null;
+}
+

--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -4,10 +4,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Button } from "@/components/ui/button";
 import { Link } from "wouter";
 import AdminNav from "@/components/admin-nav";
-
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password'),
-});
+import { getAuthHeaders } from "@/lib/auth";
 
 export default function AdminClaims() {
   const { data, isLoading } = useQuery({

--- a/client/src/pages/admin/claims/[id].tsx
+++ b/client/src/pages/admin/claims/[id].tsx
@@ -9,9 +9,10 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
+import { getAuthHeaders } from "@/lib/auth";
 
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password'),
+const authJsonHeaders = () => ({
+  ...getAuthHeaders(),
   'Content-Type': 'application/json',
 });
 
@@ -40,7 +41,7 @@ export default function AdminClaimDetail() {
     mutationFn: (updates: any) =>
       fetch(`/api/admin/claims/${id}`, {
         method: 'PATCH',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify(updates),
       }).then(res => {
         if (!res.ok) throw new Error('Failed to update claim');

--- a/client/src/pages/admin/claims/new.tsx
+++ b/client/src/pages/admin/claims/new.tsx
@@ -9,9 +9,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { getAuthHeaders } from "@/lib/auth";
 
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password'),
+const authJsonHeaders = () => ({
+  ...getAuthHeaders(),
   'Content-Type': 'application/json',
 });
 
@@ -53,7 +54,7 @@ export default function AdminClaimNew() {
     mutationFn: (data: typeof form) =>
       fetch('/api/admin/claims', {
         method: 'POST',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify(data),
       }).then(res => {
         if (!res.ok) throw new Error('Failed to create claim');

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -1,17 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Users, FileText, Target, TrendingUp, Activity, Calendar } from "lucide-react";
 import { Link } from "wouter";
 import AdminNav from "@/components/admin-nav";
-
-// Helper function to set basic auth header
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password')
-});
+import AdminLogin from "@/components/admin-login";
+import { getAuthHeaders, hasCredentials } from "@/lib/auth";
 
 export default function AdminDashboard() {
+  const [authenticated, setAuthenticated] = useState(hasCredentials());
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={() => setAuthenticated(true)} />;
+  }
+
   const { data: stats, isLoading } = useQuery({
     queryKey: ['/api/admin/stats'],
     queryFn: () => 

--- a/client/src/pages/admin/leads.tsx
+++ b/client/src/pages/admin/leads.tsx
@@ -9,10 +9,10 @@ import { Users, Search, Filter, Eye } from "lucide-react";
 import { Link } from "wouter";
 import { useToast } from "@/hooks/use-toast";
 import AdminNav from "@/components/admin-nav";
+import { getAuthHeaders } from "@/lib/auth";
 
-// Helper function to set basic auth header
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password'),
+const authJsonHeaders = () => ({
+  ...getAuthHeaders(),
   'Content-Type': 'application/json',
 });
 
@@ -28,8 +28,8 @@ export default function AdminLeads() {
   const { data: leadsData, isLoading } = useQuery({
     queryKey: ['/api/admin/leads'],
     queryFn: () => 
-      fetch('/api/admin/leads', { 
-        headers: getAuthHeaders() 
+      fetch('/api/admin/leads', {
+        headers: getAuthHeaders()
       }).then(res => {
         if (!res.ok) throw new Error('Failed to fetch leads');
         return res.json();
@@ -40,7 +40,7 @@ export default function AdminLeads() {
     mutationFn: ({ id, updates }: { id: string, updates: any }) =>
       fetch(`/api/admin/leads/${id}`, {
         method: 'PATCH',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify(updates),
       }).then(res => {
         if (!res.ok) throw new Error('Failed to update lead');

--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -13,10 +13,11 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 import { ArrowLeft, User, Car, Activity, Phone, Mail, DollarSign } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import AdminNav from "@/components/admin-nav";
+import { getAuthHeaders } from "@/lib/auth";
 
-// Helper function to set basic auth header
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password'),
+// Helper to include JSON content type with auth header
+const authJsonHeaders = () => ({
+  ...getAuthHeaders(),
   'Content-Type': 'application/json',
 });
 
@@ -50,8 +51,8 @@ export default function AdminLeadDetail() {
   const { data: leadData, isLoading } = useQuery({
     queryKey: ['/api/admin/leads', id],
     queryFn: () => 
-      fetch(`/api/admin/leads/${id}`, { 
-        headers: getAuthHeaders() 
+      fetch(`/api/admin/leads/${id}`, {
+        headers: getAuthHeaders()
       }).then(res => {
         if (!res.ok) throw new Error('Failed to fetch lead');
         return res.json();
@@ -63,7 +64,7 @@ export default function AdminLeadDetail() {
     mutationFn: (updates: any) =>
       fetch(`/api/admin/leads/${id}`, {
         method: 'PATCH',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify(updates),
       }).then(res => {
         if (!res.ok) throw new Error('Failed to update lead');
@@ -89,7 +90,7 @@ export default function AdminLeadDetail() {
     mutationFn: (quoteData: any) =>
       fetch(`/api/leads/${id}/coverage`, {
         method: 'POST',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify({
           plan: quoteData.plan,
           deductible: quoteData.deductible,
@@ -128,7 +129,7 @@ export default function AdminLeadDetail() {
     mutationFn: (policyData: any) =>
       fetch(`/api/admin/leads/${id}/convert`, {
         method: 'POST',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify(policyData),
       }).then(res => {
         if (!res.ok) throw new Error('Failed to convert lead');
@@ -154,7 +155,7 @@ export default function AdminLeadDetail() {
     mutationFn: (content: string) =>
       fetch(`/api/admin/leads/${id}/notes`, {
         method: 'POST',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify({ content }),
       }).then(res => {
         if (!res.ok) throw new Error('Failed to add note');

--- a/client/src/pages/admin/leads/new.tsx
+++ b/client/src/pages/admin/leads/new.tsx
@@ -7,9 +7,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getAuthHeaders } from "@/lib/auth";
 
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password'),
+const authJsonHeaders = () => ({
+  ...getAuthHeaders(),
   'Content-Type': 'application/json',
 });
 
@@ -32,7 +33,7 @@ export default function AdminLeadNew() {
     mutationFn: (data: typeof form) =>
       fetch('/api/admin/leads', {
         method: 'POST',
-        headers: getAuthHeaders(),
+        headers: authJsonHeaders(),
         body: JSON.stringify({
           lead: {
             firstName: data.firstName,

--- a/client/src/pages/admin/policies.tsx
+++ b/client/src/pages/admin/policies.tsx
@@ -2,10 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import AdminNav from "@/components/admin-nav";
-
-const getAuthHeaders = () => ({
-  Authorization: 'Basic ' + btoa('admin:password'),
-});
+import { getAuthHeaders } from "@/lib/auth";
 
 export default function AdminPolicies() {
   const { data, isLoading } = useQuery({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5,7 +5,8 @@ import { z } from "zod";
 import { insertLeadSchema, insertVehicleSchema, insertPolicySchema, insertClaimSchema, type InsertLead } from "@shared/schema";
 import { calculateQuote } from "../client/src/lib/pricing";
 
-const ADMIN_USER = { username: "admin", password: "password" } as const;
+// Default admin credentials for basic authentication
+const ADMIN_USER = { username: "admin", password: "BHauto123" } as const;
 
 type LeadMeta = {
   tags: string[];
@@ -39,19 +40,20 @@ const getEasternDate = () => new Date(new Date().toLocaleString('en-US', { timeZ
 const basicAuth: RequestHandler = (req, res, next) => {
   const authHeader = req.headers.authorization;
   if (!authHeader) {
-    res.set("WWW-Authenticate", 'Basic realm="Admin"');
+    // Prompt browser to display a login dialog for the admin area
+    res.set("WWW-Authenticate", 'Basic realm="BHautoprotect Admin"');
     return res.status(401).send("Authentication required");
   }
   const [type, credentials] = authHeader.split(" ");
   if (type !== "Basic" || !credentials) {
-    res.set("WWW-Authenticate", 'Basic realm="Admin"');
+    res.set("WWW-Authenticate", 'Basic realm="BHautoprotect Admin"');
     return res.status(401).send("Invalid authorization header");
   }
   const [user, pass] = Buffer.from(credentials, "base64").toString().split(":");
   if (user === ADMIN_USER.username && pass === ADMIN_USER.password) {
     return next();
   }
-  res.set("WWW-Authenticate", 'Basic realm="Admin"');
+  res.set("WWW-Authenticate", 'Basic realm="BHautoprotect Admin"');
   return res.status(401).send("Invalid credentials");
 };
 
@@ -138,8 +140,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // Admin dashboard route - authentication handled here, React handles rendering
-  app.get('/admin', basicAuth, (_req, _res, next) => {
+  // Admin dashboard route - React handles rendering and login
+  app.get('/admin', (_req, _res, next) => {
     // pass through to Vite's middleware which will serve the SPA
     next();
   });


### PR DESCRIPTION
## Summary
- add client-side admin login dialog and localStorage-based auth helpers
- default admin password set to BHauto123 and custom auth realm
- update admin dashboard and pages to use shared auth headers

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68acb319b4e883308e8693337617dbc5