### PR TITLE
fix: refresh admin leads automatically

### DIFF
--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -18,24 +18,30 @@ export default function AdminDashboard() {
 
   const { data: stats, isLoading } = useQuery({
     queryKey: ['/api/admin/stats'],
-    queryFn: () => 
-      fetch('/api/admin/stats', { 
-        headers: getAuthHeaders() 
+    queryFn: () =>
+      fetch('/api/admin/stats', {
+        headers: getAuthHeaders()
       }).then(res => {
         if (!res.ok) throw new Error('Failed to fetch stats');
         return res.json();
-      })
+      }),
+    refetchInterval: 5000,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
   });
 
   const { data: recentLeads } = useQuery({
     queryKey: ['/api/admin/leads'],
-    queryFn: () => 
-      fetch('/api/admin/leads', { 
-        headers: getAuthHeaders() 
+    queryFn: () =>
+      fetch('/api/admin/leads', {
+        headers: getAuthHeaders()
       }).then(res => {
         if (!res.ok) throw new Error('Failed to fetch leads');
         return res.json();
-      })
+      }),
+    refetchInterval: 5000,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
   });
 
   if (isLoading) {

--- a/client/src/pages/admin/leads.tsx
+++ b/client/src/pages/admin/leads.tsx
@@ -27,13 +27,16 @@ export default function AdminLeads() {
 
   const { data: leadsData, isLoading } = useQuery({
     queryKey: ['/api/admin/leads'],
-    queryFn: () => 
+    queryFn: () =>
       fetch('/api/admin/leads', {
         headers: getAuthHeaders()
       }).then(res => {
         if (!res.ok) throw new Error('Failed to fetch leads');
         return res.json();
-      })
+      }),
+    refetchInterval: 5000,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
   });
 
   const updateLeadMutation = useMutation({


### PR DESCRIPTION
## Summary
- refresh admin stats and leads on a timer and on window focus
- poll lead list so new quote requests appear without manual refresh

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68acb8d7b25483308433b68e17283344