### PR TITLE
Use static assets in production

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,6 @@
 import express from "express";
-import { createServer } from "http";
 import { registerRoutes } from "./routes";
-import { setupVite, log } from "./vite";
+import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 
@@ -15,7 +14,11 @@ async function startServer() {
   const port = parseInt(process.env.PORT || "5000");
   const host = process.env.HOST || "0.0.0.0";
 
-  await setupVite(app, server);
+  if (process.env.NODE_ENV === "production") {
+    serveStatic(app);
+  } else {
+    await setupVite(app, server);
+  }
 
   server.listen(port, host, () => {
     log(`serving on port ${port}`);


### PR DESCRIPTION
## Summary
- Serve static assets instead of Vite middleware when NODE_ENV is production

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68baea94977c8330a8b067370404e9a2