### PR TITLE
Initialize metadata for new quote leads

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -91,20 +91,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
       });
       
       // Create vehicle
-      await storage.createVehicle({
-        ...vehicleData,
-        leadId: lead.id,
-      });
-      
-      res.json({
-        data: lead,
-        message: "Lead created successfully"
-      });
-    } catch (error) {
-      console.error("Error creating lead:", error);
-      res.status(400).json({ message: "Invalid lead data" });
-    }
-  });
+        await storage.createVehicle({
+          ...vehicleData,
+          leadId: lead.id,
+        });
+
+        // Initialize metadata so newly created leads are visible in admin views
+        leadMeta[lead.id] = DEFAULT_META;
+
+        res.status(201).json({
+          data: lead,
+          message: "Lead created successfully"
+        });
+      } catch (error) {
+        console.error("Error creating lead:", error);
+        res.status(400).json({ message: "Invalid lead data" });
+      }
+    });
 
   // Get leads (for future admin use)
   app.get('/api/leads', async (req, res) => {


### PR DESCRIPTION
## Summary
- Ensure new leads created from quote requests have default metadata so they display in admin
- Return HTTP 201 when a lead is created

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68baec7584ac8330be42ab4ddd17b2ed