### PR TITLE
Ensure admin-created leads are tracked

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -251,7 +251,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         leadId: lead.id,
       });
 
-      res.json({
+      // Ensure newly created leads are tracked for admin views
+      leadMeta[lead.id] = DEFAULT_META;
+
+      res.status(201).json({
         data: { lead, vehicle },
         message: 'Lead created successfully',
       });


### PR DESCRIPTION
## Summary
- set default metadata for leads created through the admin API so they are visible and stored consistently
- return 201 status when a lead is created via admin endpoint

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68baf0cf219c8330983e1d524ae0c9ad