### PR TITLE
feat: add policy detail page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+uploads

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import AdminLeads from "@/pages/admin/leads";
 import AdminLeadDetail from "@/pages/admin/leads/[id]";
 import AdminLeadNew from "@/pages/admin/leads/new";
 import AdminPolicies from "@/pages/admin/policies";
+import AdminPolicyDetail from "@/pages/admin/policies/[id]";
 import AdminClaims from "@/pages/admin/claims";
 import AdminClaimDetail from "@/pages/admin/claims/[id]";
 import AdminClaimNew from "@/pages/admin/claims/new";
@@ -31,7 +32,9 @@ function Router() {
       <Route path="/admin/leads/new" component={AdminLeadNew} />
       <Route path="/admin/leads/:id" component={AdminLeadDetail} />
       <Route path="/admin/leads" component={AdminLeads} />
+      <Route path="/admin/policies/:id" component={AdminPolicyDetail} />
       <Route path="/admin/policies" component={AdminPolicies} />
+      <Route path="/policy/:id" component={AdminPolicyDetail} />
       <Route path="/admin/claims/new" component={AdminClaimNew} />
       <Route path="/admin/claims/:id" component={AdminClaimDetail} />
       <Route path="/admin/claims" component={AdminClaims} />

--- a/client/src/pages/admin/policies.tsx
+++ b/client/src/pages/admin/policies.tsx
@@ -1,8 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
 import AdminNav from "@/components/admin-nav";
 import { getAuthHeaders } from "@/lib/auth";
+import { Link } from "wouter";
+import { Eye } from "lucide-react";
 
 export default function AdminPolicies() {
   const { data, isLoading } = useQuery({
@@ -52,6 +55,7 @@ export default function AdminPolicies() {
                     <TableHead>Monthly Payment</TableHead>
                     <TableHead>Total Payments</TableHead>
                     <TableHead>Created</TableHead>
+                    <TableHead>Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -72,11 +76,19 @@ export default function AdminPolicies() {
                       <TableCell>{policy.monthlyPayment != null ? `$${policy.monthlyPayment}` : 'N/A'}</TableCell>
                       <TableCell>{policy.totalPayments != null ? `$${policy.totalPayments}` : 'N/A'}</TableCell>
                       <TableCell>{new Date(policy.createdAt).toLocaleDateString()}</TableCell>
+                      <TableCell>
+                        <Button size="sm" variant="outline" asChild>
+                          <Link href={`/admin/policies/${policy.id}`}>
+                            <Eye className="h-4 w-4 mr-1" />
+                            View
+                          </Link>
+                        </Button>
+                      </TableCell>
                     </TableRow>
                   ))}
                   {policies.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={15} className="text-center py-4 text-gray-500">
+                      <TableCell colSpan={16} className="text-center py-4 text-gray-500">
                         No policies found
                       </TableCell>
                     </TableRow>

--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -1,0 +1,164 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useParams, Link } from "wouter";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import AdminNav from "@/components/admin-nav";
+import { getAuthHeaders } from "@/lib/auth";
+import { ArrowLeft } from "lucide-react";
+
+export default function AdminPolicyDetail() {
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ["/api/admin/policies", id],
+    queryFn: () =>
+      fetch(`/api/admin/policies/${id}`, { headers: getAuthHeaders() }).then(res => {
+        if (!res.ok) throw new Error("Failed to fetch policy");
+        return res.json();
+      }),
+    enabled: !!id,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  const policy = data?.data;
+  const lead = policy?.lead || {};
+  const vehicle = policy?.vehicle || {};
+  const notes = policy?.notes || [];
+  const files = policy?.files || [];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+        <Button variant="ghost" asChild>
+          <Link href="/admin/policies">
+            <ArrowLeft className="h-4 w-4 mr-2" /> Back to Policies
+          </Link>
+        </Button>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Policy Details</CardTitle>
+            <CardDescription>ID: {policy.id}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+            <div><span className="font-medium">Package:</span> {policy.package || "N/A"}</div>
+            <div><span className="font-medium">Policy Start:</span> {policy.policyStartDate ? new Date(policy.policyStartDate).toLocaleDateString() : "N/A"}</div>
+            <div><span className="font-medium">Expiration Date:</span> {policy.expirationDate ? new Date(policy.expirationDate).toLocaleDateString() : "N/A"}</div>
+            <div><span className="font-medium">Expiration Miles:</span> {policy.expirationMiles ?? "N/A"}</div>
+            <div><span className="font-medium">Deductible:</span> {policy.deductible != null ? `$${policy.deductible}` : "N/A"}</div>
+            <div><span className="font-medium">Total Premium:</span> {policy.totalPremium != null ? `$${policy.totalPremium}` : "N/A"}</div>
+            <div><span className="font-medium">Down Payment:</span> {policy.downPayment != null ? `$${policy.downPayment}` : "N/A"}</div>
+            <div><span className="font-medium">Monthly Payment:</span> {policy.monthlyPayment != null ? `$${policy.monthlyPayment}` : "N/A"}</div>
+            <div><span className="font-medium">Total Payments:</span> {policy.totalPayments != null ? `$${policy.totalPayments}` : "N/A"}</div>
+            <div><span className="font-medium">Created:</span> {new Date(policy.createdAt).toLocaleDateString()}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Customer</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+            <div><span className="font-medium">Name:</span> {lead ? `${lead.firstName ?? ''} ${lead.lastName ?? ''}`.trim() || 'N/A' : 'N/A'}</div>
+            <div><span className="font-medium">Email:</span> {lead.email || 'N/A'}</div>
+            <div><span className="font-medium">Phone:</span> {lead.phone || 'N/A'}</div>
+            <div><span className="font-medium">State:</span> {lead.state || 'N/A'}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Vehicle</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+            <div><span className="font-medium">Year:</span> {vehicle.year || 'N/A'}</div>
+            <div><span className="font-medium">Make:</span> {vehicle.make || 'N/A'}</div>
+            <div><span className="font-medium">Model:</span> {vehicle.model || 'N/A'}</div>
+            <div><span className="font-medium">Trim:</span> {vehicle.trim || 'N/A'}</div>
+            <div><span className="font-medium">VIN:</span> {vehicle.vin || 'N/A'}</div>
+            <div><span className="font-medium">Odometer:</span> {vehicle.odometer != null ? vehicle.odometer : 'N/A'}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Notes</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form
+              onSubmit={async e => {
+                e.preventDefault();
+                const form = e.currentTarget;
+                const textarea = form.elements.namedItem('note') as HTMLTextAreaElement;
+                await fetch(`/api/admin/policies/${id}/notes`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+                  body: JSON.stringify({ content: textarea.value })
+                });
+                textarea.value = '';
+                queryClient.invalidateQueries({ queryKey: ["/api/admin/policies", id] });
+              }}
+              className="space-y-2"
+            >
+              <textarea name="note" className="w-full border rounded p-2" placeholder="Add a note" />
+              <Button type="submit">Add Note</Button>
+            </form>
+            <ul className="mt-4 space-y-2">
+              {notes.map((n: any) => (
+                <li key={n.id} className="text-sm border-b pb-2">
+                  <div>{n.content}</div>
+                  <div className="text-xs text-gray-500">{new Date(n.createdAt).toLocaleString()}</div>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Files</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form
+              onSubmit={async e => {
+                e.preventDefault();
+                const formData = new FormData(e.currentTarget as HTMLFormElement);
+                const file = formData.get('file') as File | null;
+                if (file) {
+                  await fetch(`/api/admin/policies/${id}/files`, {
+                    method: 'POST',
+                    headers: { 'x-filename': file.name, ...getAuthHeaders() },
+                    body: file
+                  });
+                  queryClient.invalidateQueries({ queryKey: ["/api/admin/policies", id] });
+                }
+                (e.currentTarget as HTMLFormElement).reset();
+              }}
+              className="space-y-2"
+            >
+              <input name="file" type="file" />
+              <Button type="submit">Upload File</Button>
+            </form>
+            <ul className="mt-4 space-y-2">
+              {files.map((f: any) => (
+                <li key={f.id}>
+                  <a className="text-primary underline" href={`/${f.filePath}`} target="_blank" rel="noreferrer">
+                    {f.fileName}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/policy/[id].tsx
+++ b/client/src/pages/policy/[id].tsx
@@ -1,0 +1,1 @@
+export { default } from "../admin/policies/[id]";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,8 +1,11 @@
 import type { Express } from "express";
+import express from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { z } from "zod";
-import { insertLeadSchema, insertVehicleSchema, insertPolicySchema, insertClaimSchema, type InsertLead } from "@shared/schema";
+import { insertLeadSchema, insertVehicleSchema, insertPolicySchema, insertClaimSchema, insertPolicyNoteSchema, type InsertLead } from "@shared/schema";
+import fs from "fs";
+import path from "path";
 import { calculateQuote } from "../client/src/lib/pricing";
 
 type LeadMeta = {
@@ -38,6 +41,7 @@ const getEasternDate = () =>
   );
 
 export async function registerRoutes(app: Express): Promise<Server> {
+  app.use('/uploads', express.static('uploads'));
 
   // Public quote estimation endpoint
   app.post('/api/quote/estimate', async (req, res) => {
@@ -449,6 +453,50 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error('Error fetching policies:', error);
       res.status(500).json({ message: 'Failed to fetch policies' });
+    }
+  });
+
+  // Admin: get policy by id
+  app.get('/api/admin/policies/:id', async (req, res) => {
+    try {
+      const policy = await storage.getPolicy(req.params.id);
+      if (!policy) {
+        return res.status(404).json({ message: 'Policy not found' });
+      }
+      res.json({ data: policy, message: 'Policy retrieved successfully' });
+    } catch (error) {
+      console.error('Error fetching policy:', error);
+      res.status(500).json({ message: 'Failed to fetch policy' });
+    }
+  });
+
+  // Admin: add note to policy
+  app.post('/api/admin/policies/:id/notes', async (req, res) => {
+    try {
+      const data = insertPolicyNoteSchema.pick({ content: true }).parse(req.body);
+      const note = await storage.createPolicyNote({ policyId: req.params.id, content: data.content });
+      res.json({ data: note, message: 'Note added successfully' });
+    } catch (error) {
+      console.error('Error adding policy note:', error);
+      res.status(400).json({ message: 'Invalid note data' });
+    }
+  });
+
+  // Admin: upload file to policy
+  app.post('/api/admin/policies/:id/files', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
+    try {
+      const filename = req.header('x-filename');
+      if (!filename || !req.body || !(req.body instanceof Buffer)) {
+        return res.status(400).json({ message: 'File data missing' });
+      }
+      fs.mkdirSync('uploads', { recursive: true });
+      const filePath = path.join('uploads', `${Date.now()}-${filename}`);
+      fs.writeFileSync(filePath, req.body);
+      const file = await storage.createPolicyFile({ policyId: req.params.id, fileName: filename, filePath });
+      res.json({ data: file, message: 'File uploaded successfully' });
+    } catch (error) {
+      console.error('Error uploading policy file:', error);
+      res.status(400).json({ message: 'Invalid file data' });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -124,6 +124,21 @@ export const claims = pgTable("claims", {
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
+export const policyNotes = pgTable("policy_notes", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  policyId: varchar("policy_id").references(() => policies.id, { onDelete: 'cascade' }).notNull(),
+  content: text("content").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const policyFiles = pgTable("policy_files", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  policyId: varchar("policy_id").references(() => policies.id, { onDelete: 'cascade' }).notNull(),
+  fileName: text("file_name").notNull(),
+  filePath: text("file_path").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Relations
 export const leadsRelations = relations(leads, ({ one, many }) => ({
   vehicle: one(vehicles),
@@ -165,6 +180,20 @@ export const claimsRelations = relations(claims, ({ one }) => ({
   }),
 }));
 
+export const policyNotesRelations = relations(policyNotes, ({ one }) => ({
+  policy: one(policies, {
+    fields: [policyNotes.policyId],
+    references: [policies.id],
+  }),
+}));
+
+export const policyFilesRelations = relations(policyFiles, ({ one }) => ({
+  policy: one(policies, {
+    fields: [policyFiles.policyId],
+    references: [policies.id],
+  }),
+}));
+
 // Schemas for validation
 export const insertLeadSchema = createInsertSchema(leads).omit({
   id: true,
@@ -197,6 +226,16 @@ export const insertClaimSchema = createInsertSchema(claims).omit({
   updatedAt: true,
 });
 
+export const insertPolicyNoteSchema = createInsertSchema(policyNotes).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertPolicyFileSchema = createInsertSchema(policyFiles).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Types
 export type Lead = typeof leads.$inferSelect;
 export type InsertLead = z.infer<typeof insertLeadSchema>;
@@ -210,3 +249,7 @@ export type Policy = typeof policies.$inferSelect;
 export type InsertPolicy = z.infer<typeof insertPolicySchema>;
 export type Claim = typeof claims.$inferSelect;
 export type InsertClaim = z.infer<typeof insertClaimSchema>;
+export type PolicyNote = typeof policyNotes.$inferSelect;
+export type InsertPolicyNote = z.infer<typeof insertPolicyNoteSchema>;
+export type PolicyFile = typeof policyFiles.$inferSelect;
+export type InsertPolicyFile = z.infer<typeof insertPolicyFileSchema>;


### PR DESCRIPTION
## Summary
- add API endpoint and storage method to retrieve a single policy with lead and vehicle data
- create admin policy detail page and public `/policy/:id` route
- link policies list to detail page via view action
- allow adding notes and uploading files on policy detail page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bcb49450188330bd5d1fdd9c364d78