### PR TITLE
Improve mobile nav and clarify quote buttons

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -1,11 +1,20 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Menu } from "lucide-react";
+import { Menu, X } from "lucide-react";
 
 interface NavigationProps {
   onGetQuote: () => void;
 }
 
 export default function Navigation({ onGetQuote }: NavigationProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
+  const handleQuote = () => {
+    onGetQuote();
+    setIsMenuOpen(false);
+  };
+
   return (
     <nav className="bg-white shadow-sm sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -42,7 +51,7 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
                 Claims
               </a>
               <Button
-                className="bg-primary text-white hover:bg-secondary"
+                className="bg-blue-600 text-white hover:bg-blue-700"
                 size="sm"
                 onClick={onGetQuote}
               >
@@ -51,11 +60,52 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
             </div>
           </div>
           <div className="md:hidden">
-            <button className="text-gray-700">
-              <Menu className="w-6 h-6" />
+            <button className="text-gray-700" onClick={toggleMenu} aria-label="Toggle Menu">
+              {isMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
             </button>
           </div>
         </div>
+        {isMenuOpen && (
+          <div className="md:hidden">
+            <div className="px-2 pt-2 pb-3 space-y-1">
+              <a
+                href="#"
+                className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-primary"
+                onClick={toggleMenu}
+              >
+                Coverage Plans
+              </a>
+              <a
+                href="/about"
+                className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-primary"
+                onClick={toggleMenu}
+              >
+                About
+              </a>
+              <a
+                href="/faq"
+                className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-primary"
+                onClick={toggleMenu}
+              >
+                FAQ
+              </a>
+              <a
+                href="/claims"
+                className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-primary"
+                onClick={toggleMenu}
+              >
+                Claims
+              </a>
+              <Button
+                className="w-full bg-blue-600 text-white hover:bg-blue-700 mt-2"
+                size="sm"
+                onClick={handleQuote}
+              >
+                Get Quote
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { Star, Shield, Award, Check, Users, FileText, Clock, DollarSign } from "lucide-react";
+import { Star, Shield, Award, Check, Users, FileText, Clock, DollarSign, Facebook, Twitter, Instagram } from "lucide-react";
 import Navigation from "@/components/navigation";
 import QuoteModal from "@/components/quote-modal";
 import { COVERAGE_PLANS } from "@/lib/constants";
@@ -33,7 +33,7 @@ export default function Landing() {
               <div className="flex justify-center sm:justify-start">
                 <Button
                   size="lg"
-                  className="bg-white text-primary hover:bg-gray-100 px-8 py-6 text-lg"
+                  className="bg-blue-600 text-white hover:bg-blue-700 px-8 py-6 text-lg"
                   onClick={openQuoteModal}
                 >
                   Get My Free Quote
@@ -107,7 +107,7 @@ export default function Landing() {
       </section>
 
       {/* Plan Comparison */}
-      <section className="bg-white py-20">
+      <section id="plans" className="bg-white py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl lg:text-4xl font-bold text-gray-900 mb-4">Choose Your Protection Level</h2>
@@ -129,7 +129,10 @@ export default function Landing() {
                     </li>
                   ))}
                 </ul>
-                <Button className="w-full" variant="outline" onClick={openQuoteModal}>
+                <Button
+                  className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                  onClick={openQuoteModal}
+                >
                   Request Quote
                 </Button>
               </CardContent>
@@ -153,7 +156,10 @@ export default function Landing() {
                     </li>
                   ))}
                 </ul>
-                <Button className="w-full" onClick={openQuoteModal}>
+                <Button
+                  className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                  onClick={openQuoteModal}
+                >
                   Request Quote
                 </Button>
               </CardContent>
@@ -174,7 +180,10 @@ export default function Landing() {
                     </li>
                   ))}
                 </ul>
-                <Button className="w-full" variant="outline" onClick={openQuoteModal}>
+                <Button
+                  className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                  onClick={openQuoteModal}
+                >
                   Request Quote
                 </Button>
               </CardContent>
@@ -318,9 +327,9 @@ export default function Landing() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl lg:text-4xl font-bold mb-4">Ready to Protect Your Vehicle?</h2>
           <p className="text-xl text-blue-100 mb-8">Get your free quote in less than 3 minutes. No obligations, no hassle.</p>
-          <Button 
-            size="lg" 
-            className="bg-white text-primary hover:bg-gray-100"
+          <Button
+            size="lg"
+            className="bg-blue-600 text-white hover:bg-blue-700"
             onClick={openQuoteModal}
           >
             Get My Free Quote Now
@@ -336,36 +345,57 @@ export default function Landing() {
               <h3 className="text-2xl font-bold mb-4">BH Auto Protect</h3>
               <p className="text-gray-400 mb-4">Protecting your vehicle and your wallet with comprehensive extended warranty coverage.</p>
               <div className="flex space-x-4">
-                <div className="w-6 h-6 bg-gray-600 rounded"></div>
-                <div className="w-6 h-6 bg-gray-600 rounded"></div>
-                <div className="w-6 h-6 bg-gray-600 rounded"></div>
+                <a
+                  href="https://facebook.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Facebook"
+                >
+                  <Facebook className="w-6 h-6 text-gray-400 hover:text-white" />
+                </a>
+                <a
+                  href="https://twitter.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Twitter"
+                >
+                  <Twitter className="w-6 h-6 text-gray-400 hover:text-white" />
+                </a>
+                <a
+                  href="https://instagram.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Instagram"
+                >
+                  <Instagram className="w-6 h-6 text-gray-400 hover:text-white" />
+                </a>
               </div>
             </div>
             <div>
               <h4 className="text-lg font-semibold mb-4">Coverage</h4>
               <ul className="space-y-2 text-gray-400">
-                <li><a href="#" className="hover:text-white">Basic Plans</a></li>
-                <li><a href="#" className="hover:text-white">Gold Coverage</a></li>
-                <li><a href="#" className="hover:text-white">Platinum Protection</a></li>
-                <li><a href="#" className="hover:text-white">Add-On Options</a></li>
+                <li><a href="#plans" className="hover:text-white">Basic Plans</a></li>
+                <li><a href="#plans" className="hover:text-white">Gold Coverage</a></li>
+                <li><a href="#plans" className="hover:text-white">Platinum Protection</a></li>
+                <li><a href="#plans" className="hover:text-white">Add-On Options</a></li>
               </ul>
             </div>
             <div>
               <h4 className="text-lg font-semibold mb-4">Support</h4>
               <ul className="space-y-2 text-gray-400">
-                <li><a href="#" className="hover:text-white">File a Claim</a></li>
-                <li><a href="#" className="hover:text-white">Find a Shop</a></li>
-                <li><a href="#" className="hover:text-white">Customer Service</a></li>
-                <li><a href="#" className="hover:text-white">FAQ</a></li>
+                <li><a href="/claims" className="hover:text-white">File a Claim</a></li>
+                <li><a href="/claims" className="hover:text-white">Find a Shop</a></li>
+                <li><a href="/about" className="hover:text-white">Customer Service</a></li>
+                <li><a href="/faq" className="hover:text-white">FAQ</a></li>
               </ul>
             </div>
             <div>
               <h4 className="text-lg font-semibold mb-4">Company</h4>
               <ul className="space-y-2 text-gray-400">
-                <li><a href="#" className="hover:text-white">About Us</a></li>
-                <li><a href="#" className="hover:text-white">Careers</a></li>
-                <li><a href="#" className="hover:text-white">Press</a></li>
-                <li><a href="#" className="hover:text-white">Contact</a></li>
+                <li><a href="/about" className="hover:text-white">About Us</a></li>
+                <li><a href="/" className="hover:text-white">Careers</a></li>
+                <li><a href="/" className="hover:text-white">Press</a></li>
+                <li><a href="/" className="hover:text-white">Contact</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add toggleable mobile navigation menu and style navigation quote button blue
- Restyle all quote call-to-action buttons to blue for better visibility
- Make footer links functional with social icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bd8042e3b8833084e0a9c8433a3e15