### PR TITLE
Add plans and contact pages with updated navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,6 +19,8 @@ import AdminClaimNew from "@/pages/admin/claims/new";
 import About from "@/pages/about";
 import FAQ from "@/pages/faq";
 import Claims from "@/pages/claims";
+import Plans from "@/pages/plans";
+import Contact from "@/pages/contact";
 
 function Router() {
   return (
@@ -28,6 +30,8 @@ function Router() {
       <Route path="/about" component={About} />
       <Route path="/faq" component={FAQ} />
       <Route path="/claims" component={Claims} />
+      <Route path="/plans" component={Plans} />
+      <Route path="/contact" component={Contact} />
       <Route path="/legal/privacy" component={PrivacyPage} />
       <Route path="/admin/leads/new" component={AdminLeadNew} />
       <Route path="/admin/leads/:id" component={AdminLeadDetail} />

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -21,13 +21,15 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <h1 className="text-2xl font-bold text-primary">BH Auto Protect</h1>
+              <a href="/" className="text-2xl font-bold text-primary">
+                BH Auto Protect
+              </a>
             </div>
           </div>
           <div className="hidden md:block">
             <div className="ml-10 flex items-baseline space-x-4">
               <a
-                href="#"
+                href="/plans"
                 className="text-gray-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
               >
                 Coverage Plans
@@ -69,7 +71,7 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
           <div className="md:hidden">
             <div className="px-2 pt-2 pb-3 space-y-1">
               <a
-                href="#"
+                href="/plans"
                 className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-primary"
                 onClick={toggleMenu}
               >

--- a/client/src/pages/contact.tsx
+++ b/client/src/pages/contact.tsx
@@ -1,0 +1,20 @@
+import Navigation from "@/components/navigation";
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation onGetQuote={() => {}} />
+      <div className="max-w-3xl mx-auto px-4 py-16 text-center">
+        <h1 className="text-4xl font-bold text-gray-900 mb-4">Contact Us</h1>
+        <p className="text-lg text-gray-700">
+          Need assistance? We're here to help. Email us at
+          {' '}
+          <a href="mailto:support@bhautoprotect.com" className="text-primary underline">
+            support@bhautoprotect.com
+          </a>
+          {' '}and our team will be happy to assist you.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -374,18 +374,17 @@ export default function Landing() {
             <div>
               <h4 className="text-lg font-semibold mb-4">Coverage</h4>
               <ul className="space-y-2 text-gray-400">
-                <li><a href="#plans" className="hover:text-white">Basic Plans</a></li>
-                <li><a href="#plans" className="hover:text-white">Gold Coverage</a></li>
-                <li><a href="#plans" className="hover:text-white">Platinum Protection</a></li>
-                <li><a href="#plans" className="hover:text-white">Add-On Options</a></li>
+                <li><a href="/plans" className="hover:text-white">Basic Plans</a></li>
+                <li><a href="/plans" className="hover:text-white">Gold Coverage</a></li>
+                <li><a href="/plans" className="hover:text-white">Platinum Protection</a></li>
+                <li><a href="/plans" className="hover:text-white">Add-On Options</a></li>
               </ul>
             </div>
             <div>
               <h4 className="text-lg font-semibold mb-4">Support</h4>
               <ul className="space-y-2 text-gray-400">
                 <li><a href="/claims" className="hover:text-white">File a Claim</a></li>
-                <li><a href="/claims" className="hover:text-white">Find a Shop</a></li>
-                <li><a href="/about" className="hover:text-white">Customer Service</a></li>
+                <li><a href="/contact" className="hover:text-white">Customer Support</a></li>
                 <li><a href="/faq" className="hover:text-white">FAQ</a></li>
               </ul>
             </div>
@@ -393,9 +392,7 @@ export default function Landing() {
               <h4 className="text-lg font-semibold mb-4">Company</h4>
               <ul className="space-y-2 text-gray-400">
                 <li><a href="/about" className="hover:text-white">About Us</a></li>
-                <li><a href="/" className="hover:text-white">Careers</a></li>
-                <li><a href="/" className="hover:text-white">Press</a></li>
-                <li><a href="/" className="hover:text-white">Contact</a></li>
+                <li><a href="/contact" className="hover:text-white">Contact</a></li>
               </ul>
             </div>
           </div>

--- a/client/src/pages/plans.tsx
+++ b/client/src/pages/plans.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import Navigation from "@/components/navigation";
+import { COVERAGE_PLANS } from "@/lib/constants";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Check } from "lucide-react";
+import QuoteModal from "@/components/quote-modal";
+
+export default function Plans() {
+  const [isQuoteModalOpen, setIsQuoteModalOpen] = useState(false);
+
+  const openQuoteModal = () => setIsQuoteModalOpen(true);
+  const closeQuoteModal = () => setIsQuoteModalOpen(false);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation onGetQuote={openQuoteModal} />
+      <section className="max-w-7xl mx-auto px-4 py-12">
+        <h1 className="text-4xl font-bold text-gray-900 mb-4 text-center">Coverage Plans</h1>
+        <p className="text-lg text-gray-600 text-center mb-12">
+          Explore our plans and choose the level of protection that's right for you.
+        </p>
+        <div className="grid lg:grid-cols-3 gap-8">
+          {/* Basic Plan */}
+          <Card className="relative hover:shadow-lg transition-shadow">
+            <CardContent className="p-8">
+              <div className="text-center mb-6">
+                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.basic.name}</h3>
+                <p className="text-gray-600 mb-2">{COVERAGE_PLANS.basic.description}</p>
+              </div>
+              <ul className="space-y-4 mb-8">
+                {COVERAGE_PLANS.basic.features.map((feature) => (
+                  <li key={feature} className="flex items-center">
+                    <Check className="w-5 h-5 text-accent mr-3" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                onClick={openQuoteModal}
+              >
+                Request Quote
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Gold Plan */}
+          <Card className="relative border-2 border-primary hover:shadow-lg transition-shadow">
+            <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-primary">
+              Most Popular
+            </Badge>
+            <CardContent className="p-8">
+              <div className="text-center mb-6">
+                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.gold.name}</h3>
+                <p className="text-gray-600 mb-2">{COVERAGE_PLANS.gold.description}</p>
+              </div>
+              <ul className="space-y-4 mb-8">
+                {COVERAGE_PLANS.gold.features.map((feature) => (
+                  <li key={feature} className="flex items-center">
+                    <Check className="w-5 h-5 text-accent mr-3" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                onClick={openQuoteModal}
+              >
+                Request Quote
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Platinum Plan */}
+          <Card className="relative hover:shadow-lg transition-shadow">
+            <CardContent className="p-8">
+              <div className="text-center mb-6">
+                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.platinum.name}</h3>
+                <p className="text-gray-600 mb-2">{COVERAGE_PLANS.platinum.description}</p>
+              </div>
+              <ul className="space-y-4 mb-8">
+                {COVERAGE_PLANS.platinum.features.map((feature) => (
+                  <li key={feature} className="flex items-center">
+                    <Check className="w-5 h-5 text-accent mr-3" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                onClick={openQuoteModal}
+              >
+                Request Quote
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+      <QuoteModal isOpen={isQuoteModalOpen} onClose={closeQuoteModal} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Link BH Auto Protect logo to home and direct coverage plans nav to a new plans page
- Introduce dedicated pages for coverage plans and contacting support
- Simplify footer: remove Careers/Press/Find a Shop and point support links to contact

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bd86168dc08330aa7ed0d56bfe9a30