### PR TITLE
feat: polish thank-you page

### DIFF
--- a/client/src/pages/thank-you.tsx
+++ b/client/src/pages/thank-you.tsx
@@ -1,15 +1,34 @@
 import Navigation from "@/components/navigation";
+import { Button } from "@/components/ui/button";
+import { CheckCircle } from "lucide-react";
 
 export default function ThankYou() {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white flex flex-col">
       <Navigation onGetQuote={() => {}} />
-      <div className="max-w-3xl mx-auto px-4 py-16 text-center">
-        <h1 className="text-4xl font-bold text-gray-900 mb-4">Thank You for Your Inquiry</h1>
-        <p className="text-lg text-gray-700">
-          A BH Auto Protect specialist will contact you within 24 hours.
-        </p>
-      </div>
+      <main className="flex-grow flex items-center">
+        <div className="max-w-2xl mx-auto px-4 py-20">
+          <div className="bg-white rounded-xl shadow-md p-10 text-center">
+            <CheckCircle className="w-16 h-16 text-green-600 mx-auto mb-6" />
+            <h1 className="text-4xl font-bold text-gray-900 mb-6">
+              Thank You for Reaching Out
+            </h1>
+            <p className="text-lg text-gray-700 mb-4">
+              We appreciate your interest in BH Auto Protect. Your request has
+              been successfully received, and our dedicated specialists are
+              already reviewing your information.
+            </p>
+            <p className="text-lg text-gray-700 mb-8">
+              A member of our team will be in touch within 24 hours to craft a
+              personalized protection plan for your vehicle. We look forward to
+              ensuring your driving experience remains smooth and worry-free.
+            </p>
+            <Button asChild className="px-8 py-6 text-lg">
+              <a href="/">Return to Home</a>
+            </Button>
+          </div>
+        </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- elevate thank-you page with gradient background, icon, and descriptive copy
- add button linking back to homepage for easier navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bd8d9453c4833089a16f6f1c447057