### PR TITLE
Add admin-managed user accounts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ import AdminPolicyDetail from "@/pages/admin/policies/[id]";
 import AdminClaims from "@/pages/admin/claims";
 import AdminClaimDetail from "@/pages/admin/claims/[id]";
 import AdminClaimNew from "@/pages/admin/claims/new";
+import AdminUsers from "@/pages/admin/users";
 import About from "@/pages/about";
 import FAQ from "@/pages/faq";
 import Claims from "@/pages/claims";
@@ -45,6 +46,7 @@ function Router() {
       <Route path="/admin/claims/new" component={AdminClaimNew} />
       <Route path="/admin/claims/:id" component={AdminClaimDetail} />
       <Route path="/admin/claims" component={AdminClaims} />
+      <Route path="/admin/users" component={AdminUsers} />
       <Route path="/admin" component={AdminDashboard} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/components/admin-nav.tsx
+++ b/client/src/components/admin-nav.tsx
@@ -1,7 +1,13 @@
 import { Link } from "wouter";
+import { clearCredentials, getStoredUsername } from "@/lib/auth";
+
+function handleLogout() {
+  clearCredentials();
+  window.location.href = "/admin";
+}
 
 export default function AdminNav() {
-  const username = "admin";
+  const username = getStoredUsername() ?? "admin";
   return (
     <nav className="bg-white border-b">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -16,12 +22,19 @@ export default function AdminNav() {
             <Link href="/admin/claims" className="text-gray-700 hover:text-primary">
               Claims
             </Link>
+            <Link href="/admin/users" className="text-gray-700 hover:text-primary">
+              Users
+            </Link>
           </div>
           <div className="text-sm text-gray-600">
             Logged in as: {username}{" "}
-            <a href="/" className="ml-2 hover:underline">
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="ml-2 text-primary hover:underline"
+            >
               Logout
-            </a>
+            </button>
           </div>
         </div>
       </div>

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -8,10 +8,53 @@ export type Credentials = {
 
 const STORAGE_KEY = "adminAuth";
 
+type StoredCredentials = {
+  token: string;
+  username: string;
+};
+
+function encodeCredentials(username: string, password: string): string {
+  return btoa(`${username}:${password}`);
+}
+
+function decodeUsername(token: string | null): string | null {
+  if (!token) return null;
+  try {
+    const decoded = atob(token);
+    const separatorIndex = decoded.indexOf(":");
+    if (separatorIndex === -1) return null;
+    return decoded.slice(0, separatorIndex);
+  } catch {
+    return null;
+  }
+}
+
+function readStoredCredentials(): { token: string | null; username: string | null } {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return { token: null, username: null };
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredCredentials> | string;
+    if (typeof parsed === "string") {
+      return { token: parsed, username: decodeUsername(parsed) };
+    }
+    const token = typeof parsed.token === "string" ? parsed.token : null;
+    const username =
+      typeof parsed.username === "string"
+        ? parsed.username
+        : decodeUsername(token);
+    return { token, username };
+  } catch {
+    return { token: raw, username: decodeUsername(raw) };
+  }
+}
+
 export function setCredentials(creds: Credentials): void {
-  // Store credentials as base64 to reuse in Authorization header
-  const token = btoa(`${creds.username}:${creds.password}`);
-  localStorage.setItem(STORAGE_KEY, token);
+  const token = encodeCredentials(creds.username, creds.password);
+  const payload: StoredCredentials = { token, username: creds.username };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 }
 
 export function clearCredentials(): void {
@@ -19,7 +62,11 @@ export function clearCredentials(): void {
 }
 
 export function getAuthToken(): string | null {
-  return localStorage.getItem(STORAGE_KEY);
+  return readStoredCredentials().token;
+}
+
+export function getStoredUsername(): string | null {
+  return readStoredCredentials().username;
 }
 
 export function getAuthHeaders(): Record<string, string> {

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Users, FileText, Target, TrendingUp, Activity, Calendar } from "lucide-react";
+import { Users, FileText, Target, TrendingUp, Activity, Calendar, UserPlus } from "lucide-react";
 import { Link } from "wouter";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
@@ -209,9 +209,11 @@ export default function AdminDashboard() {
                   Manage Leads
                 </Link>
               </Button>
-              <Button variant="outline" className="h-20 flex flex-col items-center justify-center">
-                <FileText className="h-6 w-6 mb-2" />
-                Generate Reports
+              <Button variant="outline" className="h-20 flex flex-col items-center justify-center" asChild>
+                <Link href="/admin/users">
+                  <UserPlus className="h-6 w-6 mb-2" />
+                  Manage Users
+                </Link>
               </Button>
               <Button variant="outline" className="h-20 flex flex-col items-center justify-center">
                 <Target className="h-6 w-6 mb-2" />

--- a/client/src/pages/admin/users.tsx
+++ b/client/src/pages/admin/users.tsx
@@ -1,0 +1,374 @@
+import { useState, type FormEvent } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import AdminNav from "@/components/admin-nav";
+import AdminLogin from "@/components/admin-login";
+import { hasCredentials, getAuthHeaders, clearCredentials, getStoredUsername } from "@/lib/auth";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Users as UsersIcon, ShieldAlert, AlertTriangle } from "lucide-react";
+
+const authJsonHeaders = () => ({
+  ...getAuthHeaders(),
+  "Content-Type": "application/json",
+});
+
+type ApiUser = {
+  id: string;
+  username: string;
+  role: "admin" | "staff";
+  createdAt: string | null;
+};
+
+type CreateUserPayload = {
+  username: string;
+  password: string;
+  role: "admin" | "staff";
+};
+
+export default function AdminUsers() {
+  const [authenticated, setAuthenticated] = useState(hasCredentials());
+  const [forbidden, setForbidden] = useState(false);
+  const [form, setForm] = useState<CreateUserPayload>({
+    username: "",
+    password: "",
+    role: "staff",
+  });
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const currentUsername = getStoredUsername();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const usersQuery = useQuery({
+    queryKey: ["/api/admin/users"],
+    enabled: authenticated,
+    queryFn: async () => {
+      const res = await fetch("/api/admin/users", { headers: getAuthHeaders() });
+      if (res.status === 401) {
+        clearCredentials();
+        setAuthenticated(false);
+        throw new Error("Unauthorized");
+      }
+      if (res.status === 403) {
+        setForbidden(true);
+        return { data: [] };
+      }
+
+      setForbidden(false);
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data?.message || "Failed to fetch users");
+      }
+      return data;
+    },
+    refetchInterval: 5000,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+  });
+
+  const createUserMutation = useMutation({
+    mutationFn: async (payload: CreateUserPayload) => {
+      const res = await fetch("/api/admin/users", {
+        method: "POST",
+        headers: authJsonHeaders(),
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 401) {
+        clearCredentials();
+        setAuthenticated(false);
+        throw new Error("Unauthorized");
+      }
+      if (res.status === 403) {
+        setForbidden(true);
+        throw new Error("You do not have permission to manage users");
+      }
+      if (!res.ok) {
+        throw new Error(data?.message || "Failed to create user");
+      }
+      setForbidden(false);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
+      setForm({ username: "", password: "", role: "staff" });
+      toast({
+        title: "User created",
+        description: "The new user can now log in to the admin tools.",
+      });
+    },
+    onError: (error: Error) => {
+      if (error.message === "Unauthorized") return;
+      toast({
+        title: "Unable to create user",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deleteUserMutation = useMutation({
+    mutationFn: async (id: string) => {
+      setPendingDeleteId(id);
+      const res = await fetch(`/api/admin/users/${id}`, {
+        method: "DELETE",
+        headers: getAuthHeaders(),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 401) {
+        clearCredentials();
+        setAuthenticated(false);
+        throw new Error("Unauthorized");
+      }
+      if (res.status === 403) {
+        setForbidden(true);
+        throw new Error("You do not have permission to manage users");
+      }
+      if (!res.ok) {
+        throw new Error(data?.message || "Failed to delete user");
+      }
+      setForbidden(false);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
+      toast({
+        title: "User removed",
+        description: "The user can no longer access the admin tools.",
+      });
+    },
+    onError: (error: Error) => {
+      if (error.message === "Unauthorized") return;
+      toast({
+        title: "Unable to remove user",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+    onSettled: () => setPendingDeleteId(null),
+  });
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={() => setAuthenticated(true)} />;
+  }
+
+  if (usersQuery.isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (forbidden) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <AdminNav />
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <Card>
+            <CardHeader className="space-y-2">
+              <CardTitle className="flex items-center text-lg font-semibold">
+                <ShieldAlert className="h-5 w-5 text-red-500 mr-2" />
+                Access restricted
+              </CardTitle>
+              <CardDescription>
+                You must be an administrator to manage user accounts.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-gray-600">
+                Please contact a system administrator if you believe this is an error.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  if (usersQuery.error) {
+    const message = usersQuery.error instanceof Error
+      ? usersQuery.error.message
+      : "Failed to load user accounts.";
+
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <AdminNav />
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <Card>
+            <CardHeader className="space-y-2">
+              <CardTitle className="flex items-center text-lg font-semibold">
+                <AlertTriangle className="h-5 w-5 text-orange-500 mr-2" />
+                Unable to load users
+              </CardTitle>
+              <CardDescription>{message}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button onClick={() => usersQuery.refetch()} disabled={usersQuery.isFetching}>
+                Try again
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const users: ApiUser[] = usersQuery.data?.data ?? [];
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!form.username || !form.password) {
+      toast({
+        title: "Missing information",
+        description: "Please provide both a username and password.",
+        variant: "destructive",
+      });
+      return;
+    }
+    createUserMutation.mutate({ ...form, username: form.username.trim() });
+  };
+
+  const handleDelete = (id: string) => {
+    if (deleteUserMutation.isPending || pendingDeleteId === id) return;
+    const confirmed = window.confirm("Are you sure you want to remove this user?");
+    if (confirmed) {
+      deleteUserMutation.mutate(id);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center">
+            <UsersIcon className="h-6 w-6 mr-2 text-primary" />
+            User Management
+          </h1>
+          <p className="text-gray-600 mt-2 max-w-2xl">
+            Create individual logins for your team and remove access when accounts are no longer needed.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <CardTitle>Active users</CardTitle>
+              <CardDescription>Team members who can access the admin portal.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>User</TableHead>
+                      <TableHead>Role</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {users.map((user) => {
+                      const created = user.createdAt
+                        ? new Date(user.createdAt).toLocaleString("en-US", {
+                            timeZone: "America/New_York",
+                          })
+                        : "—";
+                      const isCurrentUser = currentUsername && user.username === currentUsername;
+                      const isDeleting = deleteUserMutation.isPending && pendingDeleteId === user.id;
+                      const disableDelete = !!(isCurrentUser || isDeleting);
+
+                      return (
+                        <TableRow key={user.id}>
+                          <TableCell className="font-medium">{user.username}</TableCell>
+                          <TableCell>
+                            <Badge variant={user.role === "admin" ? "default" : "secondary"}>
+                              {user.role === "admin" ? "Admin" : "Staff"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>{created}</TableCell>
+                          <TableCell className="text-right space-x-2">
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              disabled={disableDelete}
+                              onClick={() => handleDelete(user.id)}
+                            >
+                              {isDeleting ? "Removing..." : "Remove"}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                    {users.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-center text-gray-500 py-8">
+                          No users found. Use the form to invite your team.
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Add a user</CardTitle>
+              <CardDescription>Provide a unique username and secure password.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-gray-700">Username</label>
+                  <Input
+                    required
+                    value={form.username}
+                    onChange={(event) => setForm((prev) => ({ ...prev, username: event.target.value }))}
+                    placeholder="jane.doe"
+                    autoComplete="username"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-gray-700">Password</label>
+                  <Input
+                    required
+                    type="password"
+                    value={form.password}
+                    onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+                    placeholder="Create a strong password"
+                    autoComplete="new-password"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-gray-700">Role</label>
+                  <Select
+                    value={form.role}
+                    onValueChange={(value: "admin" | "staff") => setForm((prev) => ({ ...prev, role: value }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a role" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="staff">Staff</SelectItem>
+                      <SelectItem value="admin">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button type="submit" className="w-full" disabled={createUserMutation.isPending}>
+                  {createUserMutation.isPending ? "Creating..." : "Add user"}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/password.ts
+++ b/server/password.ts
@@ -1,0 +1,26 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
+
+const SALT_LENGTH = 16;
+const KEY_LENGTH = 64;
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(SALT_LENGTH).toString("hex");
+  const hashedPassword = scryptSync(password, salt, KEY_LENGTH);
+  return `${salt}:${hashedPassword.toString("hex")}`;
+}
+
+export function verifyPassword(password: string, storedHash: string): boolean {
+  const [salt, key] = storedHash.split(":");
+  if (!salt || !key) {
+    return false;
+  }
+
+  const hashedBuffer = scryptSync(password, salt, KEY_LENGTH);
+  const keyBuffer = Buffer.from(key, "hex");
+
+  if (hashedBuffer.length !== keyBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(hashedBuffer, keyBuffer);
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -10,6 +10,7 @@ import {
   boolean,
   pgEnum,
   decimal,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
@@ -26,6 +27,17 @@ export const claimStatusEnum = pgEnum('claim_status', [
   'claim_covered_open',
   'claim_covered_closed',
 ]);
+export const userRoleEnum = pgEnum('user_role', ['admin', 'staff']);
+
+export const users = pgTable('users', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  username: varchar('username').notNull(),
+  passwordHash: text('password_hash').notNull(),
+  role: userRoleEnum('role').notNull().default('staff'),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (table) => ({
+  usernameIdx: uniqueIndex('users_username_idx').on(table.username),
+}));
 
 export const leads = pgTable("leads", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -236,6 +248,11 @@ export const insertPolicyFileSchema = createInsertSchema(policyFiles).omit({
   createdAt: true,
 });
 
+export const insertUserSchema = createInsertSchema(users).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Types
 export type Lead = typeof leads.$inferSelect;
 export type InsertLead = z.infer<typeof insertLeadSchema>;
@@ -253,3 +270,5 @@ export type PolicyNote = typeof policyNotes.$inferSelect;
 export type InsertPolicyNote = z.infer<typeof insertPolicyNoteSchema>;
 export type PolicyFile = typeof policyFiles.$inferSelect;
 export type InsertPolicyFile = z.infer<typeof insertPolicyFileSchema>;
+export type User = typeof users.$inferSelect;
+export type InsertUser = z.infer<typeof insertUserSchema>;


### PR DESCRIPTION
## Summary
- add a persistent users table with password hashing and ensure a default admin account exists
- protect all /api/admin routes with basic authentication and expose endpoints for listing, creating, and deleting users
- build an admin UI screen and navigation updates so administrators can manage user accounts and log out cleanly

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86b38df508330818afd5f21496fb1