### PR TITLE
Replace basic auth with session-based admin login

### DIFF
--- a/client/src/components/admin-login.tsx
+++ b/client/src/components/admin-login.tsx
@@ -1,32 +1,67 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { setCredentials, getAuthHeaders, clearCredentials } from "@/lib/auth";
+import { login, clearCredentials, getStoredUsername, checkSession } from "@/lib/auth";
 
 type Props = {
   onSuccess: () => void;
 };
 
 export default function AdminLogin({ onSuccess }: Props) {
-  const [username, setUsername] = useState("admin");
-  const [password, setPassword] = useState("BHauto123");
+  const [username, setUsername] = useState(getStoredUsername() ?? "");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    checkSession()
+      .then((isLoggedIn) => {
+        if (!active) return;
+        if (isLoggedIn) {
+          onSuccess();
+        } else {
+          setChecking(false);
+        }
+      })
+      .catch(() => {
+        if (!active) return;
+        setChecking(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [onSuccess]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setCredentials({ username, password });
+    setLoading(true);
+    setError("");
 
-    // Attempt a simple authenticated request to verify credentials
-    const res = await fetch("/api/admin/stats", { headers: getAuthHeaders() });
-    if (res.ok) {
+    const result = await login({ username, password });
+    setLoading(false);
+
+    if (result.success) {
+      setPassword("");
       setError("");
       onSuccess();
     } else {
       clearCredentials();
-      setError("Invalid username or password");
+      setError(result.message);
     }
   };
+
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
@@ -39,17 +74,19 @@ export default function AdminLogin({ onSuccess }: Props) {
             <Input
               placeholder="Username"
               value={username}
+              autoComplete="username"
               onChange={(e) => setUsername(e.target.value)}
             />
             <Input
               type="password"
               placeholder="Password"
               value={password}
+              autoComplete="current-password"
               onChange={(e) => setPassword(e.target.value)}
             />
             {error && <p className="text-sm text-red-500">{error}</p>}
-            <Button type="submit" className="w-full">
-              Login
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Logging in..." : "Login"}
             </Button>
           </form>
         </CardContent>

--- a/client/src/hooks/use-admin-auth.ts
+++ b/client/src/hooks/use-admin-auth.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from "react";
+import { checkSession } from "@/lib/auth";
+
+export function useAdminAuth() {
+  const [authenticated, setAuthenticated] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    checkSession()
+      .then((isLoggedIn) => {
+        if (!active) return;
+        setAuthenticated(isLoggedIn);
+        setChecking(false);
+      })
+      .catch(() => {
+        if (!active) return;
+        setAuthenticated(false);
+        setChecking(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const markAuthenticated = useCallback(() => {
+    setAuthenticated(true);
+  }, []);
+
+  const markLoggedOut = useCallback(() => {
+    setAuthenticated(false);
+  }, []);
+
+  return { authenticated, checking, markAuthenticated, markLoggedOut };
+}
+


### PR DESCRIPTION
## Summary
- replace the server's Basic auth flow with session-backed login and logout endpoints
- add client-side session utilities and a reusable admin auth hook that drives the login component
- update admin pages to require the new session guard and clear the session when API calls return unauthorized

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c873b257f4833092048b9bcf89fd60