### PR TITLE
Update default admin password

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -374,7 +374,7 @@ export class DatabaseStorage implements IStorage {
 
   async ensureDefaultAdminUser(): Promise<void> {
     const defaultUsername = process.env.DEFAULT_ADMIN_USERNAME ?? 'admin';
-    const defaultPassword = process.env.DEFAULT_ADMIN_PASSWORD ?? 'BHauto123';
+    const defaultPassword = process.env.DEFAULT_ADMIN_PASSWORD ?? 'GPrs1234?';
     const existing = await this.getUserByUsername(defaultUsername);
     if (existing) return;
 


### PR DESCRIPTION
## Summary
- set the default admin password to GPrs1234? when no environment override is provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c87ead290c83309c4526913829d1a7