### PR TITLE
Ensure admin API requests send session cookies

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -138,6 +138,13 @@ export function clearCredentials(): void {
   }).catch(() => undefined);
 }
 
+export function fetchWithAuth(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  return fetch(input, { ...init, credentials: "include" });
+}
+
 export function getAuthHeaders(): Record<string, string> {
   return {};
 }

--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Link } from "wouter";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
-import { clearCredentials, getAuthHeaders } from "@/lib/auth";
+import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
 export default function AdminClaims() {
@@ -15,7 +15,7 @@ export default function AdminClaims() {
     queryKey: ['/api/admin/claims'],
     enabled: authenticated,
     queryFn: async () => {
-      const res = await fetch('/api/admin/claims', { headers: getAuthHeaders() });
+      const res = await fetchWithAuth('/api/admin/claims', { headers: getAuthHeaders() });
       if (res.status === 401) {
         clearCredentials();
         markLoggedOut();

--- a/client/src/pages/admin/claims/[id].tsx
+++ b/client/src/pages/admin/claims/[id].tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
-import { clearCredentials, getAuthHeaders } from "@/lib/auth";
+import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
 const authJsonHeaders = () => ({
@@ -26,7 +26,7 @@ export default function AdminClaimDetail() {
   const { data, isLoading } = useQuery({
     queryKey: ['/api/admin/claims', id],
     queryFn: async () => {
-      const res = await fetch(`/api/admin/claims/${id}`, { headers: getAuthHeaders() });
+      const res = await fetchWithAuth(`/api/admin/claims/${id}`, { headers: getAuthHeaders() });
       if (res.status === 401) {
         clearCredentials();
         markLoggedOut();
@@ -47,7 +47,7 @@ export default function AdminClaimDetail() {
 
   const updateMutation = useMutation({
     mutationFn: async (updates: any) => {
-      const res = await fetch(`/api/admin/claims/${id}`, {
+      const res = await fetchWithAuth(`/api/admin/claims/${id}`, {
         method: 'PATCH',
         headers: authJsonHeaders(),
         body: JSON.stringify(updates),

--- a/client/src/pages/admin/claims/new.tsx
+++ b/client/src/pages/admin/claims/new.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { clearCredentials, getAuthHeaders } from "@/lib/auth";
+import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
 const authJsonHeaders = () => ({
@@ -39,8 +39,8 @@ export default function AdminClaimNew() {
     enabled: authenticated,
     queryFn: async () => {
       const [polRes, leadRes] = await Promise.all([
-        fetch('/api/admin/policies', { headers: getAuthHeaders() }),
-        fetch('/api/admin/leads', { headers: getAuthHeaders() })
+        fetchWithAuth('/api/admin/policies', { headers: getAuthHeaders() }),
+        fetchWithAuth('/api/admin/leads', { headers: getAuthHeaders() })
       ]);
       if (polRes.status === 401 || leadRes.status === 401) {
         clearCredentials();
@@ -74,7 +74,7 @@ export default function AdminClaimNew() {
 
   const createClaim = useMutation({
     mutationFn: async (data: typeof form) => {
-      const res = await fetch('/api/admin/claims', {
+      const res = await fetchWithAuth('/api/admin/claims', {
         method: 'POST',
         headers: authJsonHeaders(),
         body: JSON.stringify(data),

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -6,7 +6,7 @@ import { Users, FileText, Target, TrendingUp, Activity, Calendar, UserPlus } fro
 import { Link } from "wouter";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
-import { clearCredentials, getAuthHeaders } from "@/lib/auth";
+import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
 export default function AdminDashboard() {
@@ -27,7 +27,7 @@ export default function AdminDashboard() {
   const { data: stats, isLoading } = useQuery({
     queryKey: ['/api/admin/stats'],
     queryFn: async () => {
-      const res = await fetch('/api/admin/stats', {
+      const res = await fetchWithAuth('/api/admin/stats', {
         headers: getAuthHeaders()
       });
       if (res.status === 401) {
@@ -47,7 +47,7 @@ export default function AdminDashboard() {
   const { data: recentLeads } = useQuery({
     queryKey: ['/api/admin/leads'],
     queryFn: async () => {
-      const res = await fetch('/api/admin/leads', {
+      const res = await fetchWithAuth('/api/admin/leads', {
         headers: getAuthHeaders()
       });
       if (res.status === 401) {

--- a/client/src/pages/admin/leads.tsx
+++ b/client/src/pages/admin/leads.tsx
@@ -10,7 +10,7 @@ import { Link } from "wouter";
 import { useToast } from "@/hooks/use-toast";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
-import { getAuthHeaders, clearCredentials } from "@/lib/auth";
+import { getAuthHeaders, clearCredentials, fetchWithAuth } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
 const authJsonHeaders = () => ({
@@ -39,7 +39,7 @@ export default function AdminLeads() {
   const { data: leadsData, isLoading } = useQuery({
     queryKey: ['/api/admin/leads'],
     queryFn: async () => {
-      const res = await fetch('/api/admin/leads', {
+      const res = await fetchWithAuth('/api/admin/leads', {
         headers: getAuthHeaders()
       });
       if (res.status === 401) {
@@ -62,7 +62,7 @@ export default function AdminLeads() {
 
   const updateLeadMutation = useMutation({
     mutationFn: async ({ id, updates }: { id: string, updates: any }) => {
-      const res = await fetch(`/api/admin/leads/${id}`, {
+      const res = await fetchWithAuth(`/api/admin/leads/${id}`, {
         method: 'PATCH',
         headers: authJsonHeaders(),
         body: JSON.stringify(updates),

--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -14,7 +14,7 @@ import { ArrowLeft, User, Car, Activity, Phone, Mail, DollarSign } from "lucide-
 import { useToast } from "@/hooks/use-toast";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
-import { clearCredentials, getAuthHeaders } from "@/lib/auth";
+import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
 // Helper to include JSON content type with auth header
@@ -54,7 +54,7 @@ export default function AdminLeadDetail() {
   const { data: leadData, isLoading } = useQuery({
     queryKey: ['/api/admin/leads', id],
     queryFn: async () => {
-      const res = await fetch(`/api/admin/leads/${id}`, {
+      const res = await fetchWithAuth(`/api/admin/leads/${id}`, {
         headers: getAuthHeaders()
       });
       if (res.status === 401) {
@@ -70,7 +70,7 @@ export default function AdminLeadDetail() {
 
   const updateLeadMutation = useMutation({
     mutationFn: async (updates: any) => {
-      const res = await fetch(`/api/admin/leads/${id}`, {
+      const res = await fetchWithAuth(`/api/admin/leads/${id}`, {
         method: 'PATCH',
         headers: authJsonHeaders(),
         body: JSON.stringify(updates),
@@ -145,7 +145,7 @@ export default function AdminLeadDetail() {
 
   const convertLeadMutation = useMutation({
     mutationFn: async (policyData: any) => {
-      const response = await fetch(`/api/admin/leads/${id}/convert`, {
+      const response = await fetchWithAuth(`/api/admin/leads/${id}/convert`, {
         method: 'POST',
         headers: authJsonHeaders(),
         body: JSON.stringify(policyData),
@@ -181,7 +181,7 @@ export default function AdminLeadDetail() {
 
   const addNoteMutation = useMutation({
     mutationFn: async (content: string) => {
-      const res = await fetch(`/api/admin/leads/${id}/notes`, {
+      const res = await fetchWithAuth(`/api/admin/leads/${id}/notes`, {
         method: 'POST',
         headers: authJsonHeaders(),
         body: JSON.stringify({ content }),

--- a/client/src/pages/admin/leads/new.tsx
+++ b/client/src/pages/admin/leads/new.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { clearCredentials, getAuthHeaders } from "@/lib/auth";
+import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
 const authJsonHeaders = () => ({
@@ -47,7 +47,7 @@ export default function AdminLeadNew() {
 
   const createLead = useMutation({
     mutationFn: async (data: typeof form) => {
-      const res = await fetch('/api/admin/leads', {
+      const res = await fetchWithAuth('/api/admin/leads', {
         method: 'POST',
         headers: authJsonHeaders(),
         body: JSON.stringify({

--- a/client/src/pages/admin/policies.tsx
+++ b/client/src/pages/admin/policies.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import AdminNav from "@/components/admin-nav";
-import { getAuthHeaders } from "@/lib/auth";
+import { fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { Link } from "wouter";
 import { Eye } from "lucide-react";
 
@@ -11,7 +11,7 @@ export default function AdminPolicies() {
   const { data, isLoading } = useQuery({
     queryKey: ['/api/admin/policies'],
     queryFn: () =>
-      fetch('/api/admin/policies', { headers: getAuthHeaders() }).then(res => {
+      fetchWithAuth('/api/admin/policies', { headers: getAuthHeaders() }).then(res => {
         if (!res.ok) throw new Error('Failed to fetch policies');
         return res.json();
       })

--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -17,7 +17,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import AdminNav from "@/components/admin-nav";
-import { getAuthHeaders } from "@/lib/auth";
+import { fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
 import { ArrowLeft } from "lucide-react";
 
@@ -214,7 +214,7 @@ export default function AdminPolicyDetail() {
   const { data, isLoading } = useQuery<{ data: any }>({
     queryKey: ["/api/admin/policies", id],
     queryFn: () =>
-      fetch(`/api/admin/policies/${id}`, { headers: getAuthHeaders() }).then(res => {
+      fetchWithAuth(`/api/admin/policies/${id}`, { headers: getAuthHeaders() }).then(res => {
         if (!res.ok) throw new Error("Failed to fetch policy");
         return res.json();
       }),
@@ -228,7 +228,7 @@ export default function AdminPolicyDetail() {
   } = useQuery<{ data: EmailTemplateRecord[] }>({
     queryKey: ["/api/admin/email-templates"],
     queryFn: () =>
-      fetch("/api/admin/email-templates", { headers: getAuthHeaders() }).then(res => {
+      fetchWithAuth("/api/admin/email-templates", { headers: getAuthHeaders() }).then(res => {
         if (!res.ok) throw new Error("Failed to fetch email templates");
         return res.json();
       }),
@@ -393,7 +393,7 @@ export default function AdminPolicyDetail() {
 
     setIsSavingTemplate(true);
     try {
-      const response = await fetch("/api/admin/email-templates", {
+      const response = await fetchWithAuth("/api/admin/email-templates", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -477,7 +477,7 @@ export default function AdminPolicyDetail() {
 
     setIsSendingEmail(true);
     try {
-      const response = await fetch(`/api/admin/policies/${policy.id}/email`, {
+      const response = await fetchWithAuth(`/api/admin/policies/${policy.id}/email`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -605,7 +605,7 @@ export default function AdminPolicyDetail() {
                   });
                   return;
                 }
-                await fetch(`/api/admin/policies/${policy.id}/notes`, {
+                await fetchWithAuth(`/api/admin/policies/${policy.id}/notes`, {
                   method: "POST",
                   headers: { "Content-Type": "application/json", ...getAuthHeaders() },
                   body: JSON.stringify({ content: textarea.value }),
@@ -640,7 +640,7 @@ export default function AdminPolicyDetail() {
                 const formData = new FormData(event.currentTarget as HTMLFormElement);
                 const file = formData.get("file") as File | null;
                 if (file) {
-                  await fetch(`/api/admin/policies/${policy.id}/files`, {
+                  await fetchWithAuth(`/api/admin/policies/${policy.id}/files`, {
                     method: "POST",
                     headers: { "x-filename": file.name, ...getAuthHeaders() },
                     body: file,

--- a/client/src/pages/admin/users.tsx
+++ b/client/src/pages/admin/users.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
-import { getAuthHeaders, clearCredentials, getStoredUsername } from "@/lib/auth";
+import { getAuthHeaders, clearCredentials, getStoredUsername, fetchWithAuth } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 import { useToast } from "@/hooks/use-toast";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -56,7 +56,7 @@ export default function AdminUsers() {
     queryKey: ["/api/admin/users"],
     enabled: authenticated,
     queryFn: async () => {
-      const res = await fetch("/api/admin/users", { headers: getAuthHeaders() });
+      const res = await fetchWithAuth("/api/admin/users", { headers: getAuthHeaders() });
       if (res.status === 401) {
         clearCredentials();
         markLoggedOut();
@@ -81,7 +81,7 @@ export default function AdminUsers() {
 
   const createUserMutation = useMutation({
     mutationFn: async (payload: CreateUserPayload) => {
-      const res = await fetch("/api/admin/users", {
+      const res = await fetchWithAuth("/api/admin/users", {
         method: "POST",
         headers: authJsonHeaders(),
         body: JSON.stringify(payload),
@@ -123,7 +123,7 @@ export default function AdminUsers() {
   const deleteUserMutation = useMutation({
     mutationFn: async (id: string) => {
       setPendingDeleteId(id);
-      const res = await fetch(`/api/admin/users/${id}`, {
+      const res = await fetchWithAuth(`/api/admin/users/${id}`, {
         method: "DELETE",
         headers: getAuthHeaders(),
       });


### PR DESCRIPTION
## Summary
- add a shared `fetchWithAuth` helper that always includes credentials when calling admin endpoints
- update dashboard, lead, claim, policy, and user admin pages to use the helper so session cookies are sent with every request

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c880e6d8848330aadae3e23cf553b6