### PR TITLE
Fix admin pages to avoid conditional hook usage

### DIFF
--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -12,19 +12,9 @@ import { useAdminAuth } from "@/hooks/use-admin-auth";
 export default function AdminDashboard() {
   const { authenticated, checking, markAuthenticated, markLoggedOut } = useAdminAuth();
 
-  if (checking) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
+  const queriesEnabled = authenticated && !checking;
 
-  if (!authenticated) {
-    return <AdminLogin onSuccess={markAuthenticated} />;
-  }
-
-  const { data: stats, isLoading } = useQuery({
+  const statsQuery = useQuery({
     queryKey: ['/api/admin/stats'],
     queryFn: async () => {
       const res = await fetchWithAuth('/api/admin/stats', {
@@ -41,10 +31,10 @@ export default function AdminDashboard() {
     refetchInterval: 5000,
     refetchOnWindowFocus: true,
     staleTime: 0,
-    enabled: authenticated,
+    enabled: queriesEnabled,
   });
 
-  const { data: recentLeads } = useQuery({
+  const recentLeadsQuery = useQuery({
     queryKey: ['/api/admin/leads'],
     queryFn: async () => {
       const res = await fetchWithAuth('/api/admin/leads', {
@@ -61,10 +51,10 @@ export default function AdminDashboard() {
     refetchInterval: 5000,
     refetchOnWindowFocus: true,
     staleTime: 0,
-    enabled: authenticated,
+    enabled: queriesEnabled,
   });
 
-  if (isLoading) {
+  if (checking) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
@@ -72,8 +62,20 @@ export default function AdminDashboard() {
     );
   }
 
-  const statsData = stats?.data || {};
-  const leads = recentLeads?.data?.slice(0, 5) || [];
+  if (!authenticated) {
+    return <AdminLogin onSuccess={markAuthenticated} />;
+  }
+
+  if (statsQuery.isLoading && !statsQuery.data) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  const statsData = statsQuery.data?.data || {};
+  const leads = recentLeadsQuery.data?.data?.slice(0, 5) || [];
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/client/src/pages/admin/leads.tsx
+++ b/client/src/pages/admin/leads.tsx
@@ -28,15 +28,9 @@ export default function AdminLeads() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  if (checking) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
+  const queriesEnabled = authenticated && !checking;
 
-  const { data: leadsData, isLoading } = useQuery({
+  const leadsQuery = useQuery({
     queryKey: ['/api/admin/leads'],
     queryFn: async () => {
       const res = await fetchWithAuth('/api/admin/leads', {
@@ -50,15 +44,11 @@ export default function AdminLeads() {
       if (!res.ok) throw new Error('Failed to fetch leads');
       return res.json();
     },
-    enabled: authenticated,
+    enabled: queriesEnabled,
     refetchInterval: 5000,
     refetchOnWindowFocus: true,
     staleTime: 0,
   });
-
-  if (!authenticated) {
-    return <AdminLogin onSuccess={markAuthenticated} />;
-  }
 
   const updateLeadMutation = useMutation({
     mutationFn: async ({ id, updates }: { id: string, updates: any }) => {
@@ -91,7 +81,7 @@ export default function AdminLeads() {
     },
   });
 
-  const leads = leadsData?.data || [];
+  const leads = leadsQuery.data?.data || [];
 
   const duplicateIds = useMemo(() => {
     const emails = new Map<string, string>();
@@ -221,7 +211,19 @@ export default function AdminLeads() {
     });
   };
 
-  if (isLoading) {
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={markAuthenticated} />;
+  }
+
+  if (leadsQuery.isLoading && !leadsQuery.data) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />

--- a/client/src/pages/admin/leads/new.tsx
+++ b/client/src/pages/admin/leads/new.tsx
@@ -32,19 +32,6 @@ export default function AdminLeadNew() {
   });
 
   const { authenticated, checking, markAuthenticated, markLoggedOut } = useAdminAuth();
-
-  if (checking) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
-
-  if (!authenticated) {
-    return <AdminLogin onSuccess={markAuthenticated} />;
-  }
-
   const createLead = useMutation({
     mutationFn: async (data: typeof form) => {
       const res = await fetchWithAuth('/api/admin/leads', {
@@ -87,6 +74,18 @@ export default function AdminLeadNew() {
       });
     },
   });
+
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={markAuthenticated} />;
+  }
 
   const handleChange = (field: string, value: string) => {
     setForm(prev => ({ ...prev, [field]: value }));

--- a/client/src/pages/admin/users.tsx
+++ b/client/src/pages/admin/users.tsx
@@ -44,17 +44,11 @@ export default function AdminUsers() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  if (checking) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
+  const queriesEnabled = authenticated && !checking;
 
   const usersQuery = useQuery({
     queryKey: ["/api/admin/users"],
-    enabled: authenticated,
+    enabled: queriesEnabled,
     queryFn: async () => {
       const res = await fetchWithAuth("/api/admin/users", { headers: getAuthHeaders() });
       if (res.status === 401) {
@@ -161,11 +155,19 @@ export default function AdminUsers() {
     onSettled: () => setPendingDeleteId(null),
   });
 
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
   if (!authenticated) {
     return <AdminLogin onSuccess={markAuthenticated} />;
   }
 
-  if (usersQuery.isLoading) {
+  if (usersQuery.isLoading && !usersQuery.data) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />


### PR DESCRIPTION
## Summary
- ensure admin dashboard and list pages register React Query hooks before returning early
- guard authenticated queries with `enabled` flags so they stay idle until login is confirmed
- keep login and loading branches after hook declarations to maintain consistent hook order

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c884a29d148330b29674fce24d7c3b