### PR TITLE
Handle nullable email templates when sanitizing HTML

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -64,8 +64,26 @@ const getEasternDate = () =>
     new Date().toLocaleString("en-US", { timeZone: "America/New_York" }),
   );
 
-const sanitizeRichHtml = (value: string): string => {
-  return value
+const ensureHtmlString = (value: string | null | undefined): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  try {
+    return String(value);
+  } catch {
+    return "";
+  }
+};
+
+const sanitizeRichHtml = (value: string | null | undefined): string => {
+  const input = ensureHtmlString(value);
+  if (!input) {
+    return "";
+  }
+  return input
     .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
     .replace(/on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
     .replace(/javascript:/gi, '')


### PR DESCRIPTION
## Summary
- guard HTML sanitization against null or non-string values before stripping scripts
- reuse the safe helper wherever email template HTML is sanitized to avoid runtime errors

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c886ebcf9883308bd108caa79463a1