### PR TITLE
Add default gas voucher email template

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -361,6 +361,7 @@ const buildQuoteEmail = ({
 
 export async function registerRoutes(app: Express): Promise<Server> {
   await storage.ensureDefaultAdminUser();
+  await storage.ensureDefaultEmailTemplates();
 
   const MemoryStore = createMemoryStore(session);
   const secureCookie = process.env.NODE_ENV === "production";


### PR DESCRIPTION
## Summary
- seed a branded "Gas Voucher Added" email template that includes BH Auto Protect messaging and redemption steps
- ensure default email templates are provisioned during server startup alongside the default admin user

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c893a204348330adc9f5fbef0d5817