### PR TITLE
Update coverage plans to bronze, silver, and gold

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -40,9 +40,9 @@ export default function Footer() {
           <div>
             <h4 className="text-lg font-semibold mb-4">Coverage</h4>
             <ul className="space-y-2 text-gray-400">
-              <li><a href="/plans" className="hover:text-white">Basic Plans</a></li>
-              <li><a href="/plans" className="hover:text-white">Gold Coverage</a></li>
-              <li><a href="/plans" className="hover:text-white">Platinum Protection</a></li>
+              <li><a href="/plans" className="hover:text-white">Bronze Plan</a></li>
+              <li><a href="/plans" className="hover:text-white">Silver Coverage</a></li>
+              <li><a href="/plans" className="hover:text-white">Gold Protection</a></li>
               <li><a href="/plans" className="hover:text-white">Add-On Options</a></li>
             </ul>
           </div>

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -84,9 +84,8 @@ export const US_STATES = [
 ];
 
 export const COVERAGE_PLANS = {
-  basic: {
-    name: 'Basic',
-    description: 'Essential coverage',
+  bronze: {
+    name: 'Bronze',
     features: [
       'Engine',
       'Transmission',
@@ -102,7 +101,35 @@ export const COVERAGE_PLANS = {
   },
   gold: {
     name: 'Gold',
-    description: 'Comprehensive protection',
+    description: 'Most Comprehensive!',
+    features: [
+      'Engine',
+      'Transmission',
+      'Seals & Gaskets',
+      'Cooling System',
+      'Brake System',
+      'Electrical System',
+      'Drive Axle',
+      'Trip Interruption',
+      'Gas Refill',
+      'Roadside Assistance',
+      'Rental Car',
+      'Lock Out',
+      'Steering System',
+      'ABS Brakes',
+      'AC System',
+      'Heating System',
+      'Fuel System',
+      'Turbo/Supercharger',
+      'Hi-Tech',
+      'Front Suspension',
+      'Back Suspension',
+      'AWD 4x4',
+      'Hybrid & EV Components',
+    ],
+  },
+  silver: {
+    name: 'Silver',
     features: [
       'Engine',
       'Transmission',
@@ -127,35 +154,14 @@ export const COVERAGE_PLANS = {
       'AWD 4x4',
     ],
   },
-  platinum: {
-    name: 'Platinum',
-    description: 'Maximum coverage',
-    features: [
-      'Engine',
-      'Transmission',
-      'Seals & Gaskets',
-      'Cooling System',
-      'Brake System',
-      'Electrical System',
-      'Drive Axle',
-      'Trip Interruption',
-      'Gas Refill',
-      'Roadside Assistance',
-      'Rental Car',
-      'Steering System',
-      'ABS Brakes',
-      'AC System',
-      'Heating System',
-      'Fuel System',
-      'Turbo/Supercharger',
-      'Hi-Tech',
-      'Front Suspension',
-      'Back Suspension',
-      'AWD 4x4',
-      'Hybrid & EV Components',
-    ],
-  },
-};
+} satisfies Record<
+  'bronze' | 'gold' | 'silver',
+  {
+    name: string;
+    features: readonly string[];
+    description?: string;
+  }
+>;
 
 export const DEDUCTIBLE_OPTIONS = [
   { value: 100, label: '$100', description: 'Higher premium' },

--- a/client/src/lib/pricing.ts
+++ b/client/src/lib/pricing.ts
@@ -6,7 +6,7 @@ export interface VehicleInfo {
 }
 
 export interface CoverageInfo {
-  plan: "basic" | "gold" | "platinum";
+  plan: "bronze" | "silver" | "gold";
   deductible: number;
 }
 
@@ -24,7 +24,7 @@ export interface QuoteEstimate {
 }
 
 /**
- * Basic quote estimation utility used by both client and server.
+ * Simple quote estimation utility used by both client and server.
  * The algorithm is intentionally simple and should be replaced with
  * real pricing logic in production.
  */
@@ -39,13 +39,13 @@ export function calculateQuote(
   // Base monthly price by coverage plan in dollars
   let basePrice = 0;
   switch (coverage.plan) {
-    case "basic":
+    case "bronze":
       basePrice = 60;
       break;
-    case "gold":
+    case "silver":
       basePrice = 80;
       break;
-    case "platinum":
+    case "gold":
       basePrice = 100;
       break;
   }

--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -687,9 +687,9 @@ export default function AdminLeadDetail() {
                               <SelectValue placeholder="--- Please Select ---" />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="basic">Basic</SelectItem>
+                              <SelectItem value="bronze">Bronze</SelectItem>
+                              <SelectItem value="silver">Silver</SelectItem>
                               <SelectItem value="gold">Gold</SelectItem>
-                              <SelectItem value="platinum">Platinum</SelectItem>
                             </SelectContent>
                           </Select>
                         </div>
@@ -888,9 +888,9 @@ export default function AdminLeadDetail() {
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="basic">Basic</SelectItem>
+                          <SelectItem value="bronze">Bronze</SelectItem>
+                          <SelectItem value="silver">Silver</SelectItem>
                           <SelectItem value="gold">Gold</SelectItem>
-                          <SelectItem value="platinum">Platinum</SelectItem>
                         </SelectContent>
                       </Select>
                     </div>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Star, Shield, Award, Check, Users, FileText, Clock, DollarSign } from "lucide-react";
 import Navigation from "@/components/navigation";
@@ -114,15 +113,19 @@ export default function Landing() {
             <p className="text-xl text-gray-600 max-w-2xl mx-auto">Comprehensive coverage options for every budget</p>
           </div>
           <div className="grid lg:grid-cols-3 gap-8">
-            {/* Basic Plan */}
+            {/* Bronze Plan */}
             <Card className="relative hover:shadow-lg transition-shadow">
               <CardContent className="p-8">
                 <div className="text-center mb-6">
-                  <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.basic.name}</h3>
-                  <p className="text-gray-600 mb-2">{COVERAGE_PLANS.basic.description}</p>
+                  <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.bronze.name}</h3>
+                  {COVERAGE_PLANS.bronze.description && (
+                    <p className="text-sm font-semibold text-primary">
+                      {COVERAGE_PLANS.bronze.description}
+                    </p>
+                  )}
                 </div>
                 <ul className="space-y-4 mb-8">
-                  {COVERAGE_PLANS.basic.features.map((feature) => (
+                  {COVERAGE_PLANS.bronze.features.map((feature) => (
                     <li key={feature} className="flex items-center">
                       <Check className="w-5 h-5 text-accent mr-3" />
                       <span>{feature}</span>
@@ -133,20 +136,21 @@ export default function Landing() {
                   className="w-full bg-blue-600 text-white hover:bg-blue-700"
                   onClick={openQuoteModal}
                 >
-                  Request Quote
+                  Get a Quote
                 </Button>
               </CardContent>
             </Card>
 
             {/* Gold Plan */}
             <Card className="relative border-2 border-primary hover:shadow-lg transition-shadow">
-              <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-primary">
-                Most Popular
-              </Badge>
               <CardContent className="p-8">
                 <div className="text-center mb-6">
                   <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.gold.name}</h3>
-                  <p className="text-gray-600 mb-2">{COVERAGE_PLANS.gold.description}</p>
+                  {COVERAGE_PLANS.gold.description && (
+                    <p className="text-sm font-semibold text-primary">
+                      {COVERAGE_PLANS.gold.description}
+                    </p>
+                  )}
                 </div>
                 <ul className="space-y-4 mb-8">
                   {COVERAGE_PLANS.gold.features.map((feature) => (
@@ -160,20 +164,24 @@ export default function Landing() {
                   className="w-full bg-blue-600 text-white hover:bg-blue-700"
                   onClick={openQuoteModal}
                 >
-                  Request Quote
+                  Get a Quote
                 </Button>
               </CardContent>
             </Card>
 
-            {/* Platinum Plan */}
+            {/* Silver Plan */}
             <Card className="relative hover:shadow-lg transition-shadow">
               <CardContent className="p-8">
                 <div className="text-center mb-6">
-                  <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.platinum.name}</h3>
-                  <p className="text-gray-600 mb-2">{COVERAGE_PLANS.platinum.description}</p>
+                  <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.silver.name}</h3>
+                  {COVERAGE_PLANS.silver.description && (
+                    <p className="text-sm font-semibold text-primary">
+                      {COVERAGE_PLANS.silver.description}
+                    </p>
+                  )}
                 </div>
                 <ul className="space-y-4 mb-8">
-                  {COVERAGE_PLANS.platinum.features.map((feature) => (
+                  {COVERAGE_PLANS.silver.features.map((feature) => (
                     <li key={feature} className="flex items-center">
                       <Check className="w-5 h-5 text-accent mr-3" />
                       <span>{feature}</span>
@@ -184,7 +192,7 @@ export default function Landing() {
                   className="w-full bg-blue-600 text-white hover:bg-blue-700"
                   onClick={openQuoteModal}
                 >
-                  Request Quote
+                  Get a Quote
                 </Button>
               </CardContent>
             </Card>
@@ -287,7 +295,7 @@ export default function Landing() {
                 What does an extended warranty cover?
               </AccordionTrigger>
               <AccordionContent className="text-gray-600">
-                Our extended warranties cover major mechanical breakdowns including engine, transmission, electrical systems, air conditioning, and more. Coverage varies by plan - Basic covers essential systems, Gold adds steering, suspension, and high-tech components, and Platinum extends coverage to seals, gaskets, and hybrid/EV components.
+                Our extended warranties cover major mechanical breakdowns including engine, transmission, electrical systems, air conditioning, and more. Coverage varies by plan - Bronze covers essential systems, Silver adds steering, suspension, and high-tech components, and Gold extends coverage to seals, gaskets, and hybrid/EV components.
               </AccordionContent>
             </AccordionItem>
             

--- a/client/src/pages/legal/terms.tsx
+++ b/client/src/pages/legal/terms.tsx
@@ -58,8 +58,8 @@ export default function TermsPage() {
                 <div>
                   <h3 className="text-lg font-medium text-gray-900 mb-2">Coverage Details</h3>
                   <p>
-                    Specific coverage details are outlined in your individual warranty contract. Coverage varies 
-                    by plan type (Basic, Gold, Platinum) and includes mechanical breakdown protection for
+                    Specific coverage details are outlined in your individual warranty contract. Coverage varies
+                    by plan type (Bronze, Silver, Gold) and includes mechanical breakdown protection for
                     covered components as specified in your contract terms.
                   </p>
                 </div>

--- a/client/src/pages/plans.tsx
+++ b/client/src/pages/plans.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import Navigation from "@/components/navigation";
 import { COVERAGE_PLANS } from "@/lib/constants";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Check } from "lucide-react";
 import QuoteModal from "@/components/quote-modal";
@@ -22,15 +21,19 @@ export default function Plans() {
           Explore our plans and choose the level of protection that's right for you.
         </p>
         <div className="grid lg:grid-cols-3 gap-8">
-          {/* Basic Plan */}
+          {/* Bronze Plan */}
           <Card className="relative hover:shadow-lg transition-shadow">
             <CardContent className="p-8">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.basic.name}</h3>
-                <p className="text-gray-600 mb-2">{COVERAGE_PLANS.basic.description}</p>
+                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.bronze.name}</h3>
+                {COVERAGE_PLANS.bronze.description && (
+                  <p className="text-sm font-semibold text-primary">
+                    {COVERAGE_PLANS.bronze.description}
+                  </p>
+                )}
               </div>
               <ul className="space-y-4 mb-8">
-                {COVERAGE_PLANS.basic.features.map((feature) => (
+                {COVERAGE_PLANS.bronze.features.map((feature) => (
                   <li key={feature} className="flex items-center">
                     <Check className="w-5 h-5 text-accent mr-3" />
                     <span>{feature}</span>
@@ -41,20 +44,21 @@ export default function Plans() {
                 className="w-full bg-blue-600 text-white hover:bg-blue-700"
                 onClick={openQuoteModal}
               >
-                Request Quote
+                Get a Quote
               </Button>
             </CardContent>
           </Card>
 
           {/* Gold Plan */}
           <Card className="relative border-2 border-primary hover:shadow-lg transition-shadow">
-            <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-primary">
-              Most Popular
-            </Badge>
             <CardContent className="p-8">
               <div className="text-center mb-6">
                 <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.gold.name}</h3>
-                <p className="text-gray-600 mb-2">{COVERAGE_PLANS.gold.description}</p>
+                {COVERAGE_PLANS.gold.description && (
+                  <p className="text-sm font-semibold text-primary">
+                    {COVERAGE_PLANS.gold.description}
+                  </p>
+                )}
               </div>
               <ul className="space-y-4 mb-8">
                 {COVERAGE_PLANS.gold.features.map((feature) => (
@@ -68,20 +72,24 @@ export default function Plans() {
                 className="w-full bg-blue-600 text-white hover:bg-blue-700"
                 onClick={openQuoteModal}
               >
-                Request Quote
+                Get a Quote
               </Button>
             </CardContent>
           </Card>
 
-          {/* Platinum Plan */}
+          {/* Silver Plan */}
           <Card className="relative hover:shadow-lg transition-shadow">
             <CardContent className="p-8">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.platinum.name}</h3>
-                <p className="text-gray-600 mb-2">{COVERAGE_PLANS.platinum.description}</p>
+                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.silver.name}</h3>
+                {COVERAGE_PLANS.silver.description && (
+                  <p className="text-sm font-semibold text-primary">
+                    {COVERAGE_PLANS.silver.description}
+                  </p>
+                )}
               </div>
               <ul className="space-y-4 mb-8">
-                {COVERAGE_PLANS.platinum.features.map((feature) => (
+                {COVERAGE_PLANS.silver.features.map((feature) => (
                   <li key={feature} className="flex items-center">
                     <Check className="w-5 h-5 text-accent mr-3" />
                     <span>{feature}</span>
@@ -92,7 +100,7 @@ export default function Plans() {
                 className="w-full bg-blue-600 text-white hover:bg-blue-700"
                 onClick={openQuoteModal}
               >
-                Request Quote
+                Get a Quote
               </Button>
             </CardContent>
           </Card>

--- a/replit.md
+++ b/replit.md
@@ -26,7 +26,7 @@ Preferred communication style: Simple, everyday language.
 - **Normalized Schema**: Comprehensive database schema with proper relationships and foreign keys
 - **Lead Management**: Complete lead lifecycle from initial contact through policy binding
 - **Vehicle Data**: Detailed vehicle information including VIN, odometer, make/model
-- **Quote System**: Multiple plan tiers (Basic, Gold, Platinum)
+- **Quote System**: Multiple plan tiers (Bronze, Silver, Gold)
 - **Policy Management**: Full policy lifecycle including payments and documents
 - **Audit Trail**: Comprehensive logging of user actions and data changes
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -521,7 +521,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           odometer: z.number(),
         }),
         coverage: z.object({
-          plan: z.enum(['basic', 'gold', 'platinum']),
+          plan: z.enum(['bronze', 'silver', 'gold']),
           deductible: z.number(),
         }),
         location: z.object({
@@ -646,7 +646,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Assign coverage plan to a lead
   app.post('/api/leads/:id/coverage', async (req, res) => {
     const schema = z.object({
-      plan: z.enum(['basic', 'gold', 'platinum']),
+      plan: z.enum(['bronze', 'silver', 'gold']),
       deductible: z.coerce.number(),
       termMonths: z.coerce.number().default(36),
       priceMonthly: z.coerce.number(),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
 // Enums
-export const planTypeEnum = pgEnum('plan_type', ['basic', 'gold', 'platinum']);
+export const planTypeEnum = pgEnum('plan_type', ['bronze', 'silver', 'gold']);
 export const quoteStatusEnum = pgEnum('quote_status', ['draft', 'sent', 'accepted', 'rejected']);
 export const claimStatusEnum = pgEnum('claim_status', [
   'new',


### PR DESCRIPTION
## Summary
- Replace the shared coverage plan definitions with Bronze, Silver, and Gold data and features.
- Refresh the landing and plans pages so each card matches the new plan order, checklist, and call-to-action copy.
- Update admin selects, backend validation, and schema enums to use the new plan values.

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c98257507c8330b19c7ab2b4af9dbc