### PR TITLE
Adjust email dialog sizing

### DIFF
--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -858,7 +858,7 @@ export default function AdminPolicyDetail() {
           }
         }}
       >
-        <DialogContent className="max-w-3xl">
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Send policy email</DialogTitle>
             <DialogDescription>
@@ -919,7 +919,7 @@ export default function AdminPolicyDetail() {
                       title="Email preview"
                       sandbox=""
                       srcDoc={previewSource}
-                      className="h-[420px] w-full border-0 bg-white"
+                      className="h-[60vh] max-h-[420px] w-full border-0 bg-white"
                     />
                   </div>
                 </TabsContent>


### PR DESCRIPTION
## Summary
- keep the policy email dialog within the viewport by capping its height and enabling scrolling
- make the email preview iframe responsive so it shrinks on smaller screens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9ae3de228833099d92b0747bbfed4