### PR TITLE
Add secure lead webhook endpoint and environment configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,31 @@
+# Application configuration
+NODE_ENV=development
+PORT=5000
+HOST=0.0.0.0
+
+# Database
+DATABASE_URL=postgres://username:password@localhost:5432/bhautoprotect
+
+# Session and security
+SESSION_SECRET=change-me-session-secret
+LEAD_WEBHOOK_SECRET=3b079bb3c1304d55970829d09fda0b88
+
+# Default admin credentials
+DEFAULT_ADMIN_USERNAME=admin
+DEFAULT_ADMIN_PASSWORD=GPrs1234?
+
+# Email (SMTP)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_STARTTLS=true
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=
+SMTP_CLIENT_NAME=
+SMTP_TLS_REJECT_UNAUTHORIZED=true
+
+# Replit SSO
+REPLIT_DOMAINS=
+ISSUER_URL=
+REPL_ID=


### PR DESCRIPTION
## Summary
- add a checked-in `.env` template including the new `LEAD_WEBHOOK_SECRET`
- expose a `/webhooks/leads` endpoint that validates the secret header, normalizes lead data, and stores it with existing database helpers
- guard the webhook with lightweight rate limiting and improved server-side logging

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca958911948330a29fb6cd559b84b2