### PR TITLE
Add branded logo component to navigation and footer

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import { Facebook, Twitter, Instagram } from "lucide-react";
+import Logo from "@/components/logo";
 
 export default function Footer() {
   return (
@@ -6,7 +7,12 @@ export default function Footer() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid md:grid-cols-4 gap-8">
           <div>
-            <h3 className="text-2xl font-bold mb-4">BH Auto Protect</h3>
+            <Logo
+              className="mb-4"
+              titleClassName="text-white"
+              subtitleClassName="text-blue-200"
+              textClassName="gap-1"
+            />
             <p className="text-gray-400 mb-4">
               Protecting your vehicle and your wallet with comprehensive extended warranty coverage.
             </p>

--- a/client/src/components/logo.tsx
+++ b/client/src/components/logo.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/utils";
+
+interface LogoProps {
+  className?: string;
+  showText?: boolean;
+  textClassName?: string;
+  titleClassName?: string;
+  subtitleClassName?: string;
+}
+
+export function Logo({
+  className,
+  showText = true,
+  textClassName,
+  titleClassName,
+  subtitleClassName,
+}: LogoProps) {
+  return (
+    <div className={cn("flex items-center gap-3", className)}>
+      <svg
+        viewBox="0 0 320 120"
+        role="img"
+        aria-labelledby="bh-logo-title bh-logo-desc"
+        className="h-12 w-auto"
+      >
+        <title id="bh-logo-title">BH Auto Protect</title>
+        <desc id="bh-logo-desc">Stylized car silhouette above a shield with a checkmark</desc>
+        <defs>
+          <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#0F172A" />
+            <stop offset="50%" stopColor="#1D4ED8" />
+            <stop offset="100%" stopColor="#0F172A" />
+          </linearGradient>
+        </defs>
+        <g fill="none" stroke="url(#logoGradient)" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M30 66c20-22 60-40 110-40s86 16 120 40" />
+          <path d="M36 58c12-16 48-30 104-30s96 14 116 30" opacity="0.65" />
+        </g>
+        <g transform="translate(210 50)">
+          <path
+            d="M36 4 18-4 0 4v30c0 16 8 30 18 38 10-8 18-22 18-38V4Z"
+            fill="#0F172A"
+            opacity="0.12"
+          />
+          <path
+            d="M36 0 18-8 0 0v32c0 16 8 30 18 38 10-8 18-22 18-38V0Z"
+            fill="#0B1F4E"
+          />
+          <path d="M9 16 18 26l15-18" stroke="#E0F2FE" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round" />
+        </g>
+      </svg>
+      {showText && (
+        <div className={cn("flex flex-col leading-tight", textClassName)}>
+          <span
+            className={cn(
+              "text-xl sm:text-2xl font-black tracking-tight text-slate-900",
+              titleClassName,
+            )}
+          >
+            BH <span className="text-primary">AUTO</span> PROTECT
+          </span>
+          <span
+            className={cn(
+              "text-xs sm:text-sm uppercase tracking-[0.3em] text-slate-500",
+              subtitleClassName,
+            )}
+          >
+            Extended Car Warranties
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Logo;

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Menu, X, Phone, Mail, Clock } from "lucide-react";
+import Logo from "@/components/logo";
 
 interface NavigationProps {
   onGetQuote: () => void;
@@ -51,17 +52,16 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
       <nav className="bg-white/90 backdrop-blur border-b border-blue-100/50 shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-20">
-            <div className="flex items-center space-x-3">
-              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-primary via-secondary to-primary flex items-center justify-center text-white font-bold shadow-lg">
-                BH
-              </div>
-              <a
-                href="/"
-                className="text-2xl lg:text-3xl font-extrabold tracking-tight text-primary hover:text-secondary transition-colors"
-              >
-                BH Auto Protect
-              </a>
-            </div>
+            <a
+              href="/"
+              className="group flex items-center"
+              aria-label="BH Auto Protect home"
+            >
+              <Logo
+                titleClassName="group-hover:text-secondary transition-colors"
+                subtitleClassName="group-hover:text-primary/70 transition-colors"
+              />
+            </a>
             <div className="hidden md:flex items-center gap-8">
               {navLinks.map((link) => (
                 <a


### PR DESCRIPTION
## Summary
- add a reusable SVG-based BH Auto Protect logo component with customizable text styling
- replace the navigation wordmark with the new logo for a branded header experience
- update the footer to reuse the logo and align its colors with the dark theme

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca992f63bc833087d039978416fc7f