### PR TITLE
Add admin branding management with logo upload

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import AdminClaims from "@/pages/admin/claims";
 import AdminClaimDetail from "@/pages/admin/claims/[id]";
 import AdminClaimNew from "@/pages/admin/claims/new";
 import AdminUsers from "@/pages/admin/users";
+import AdminSettings from "@/pages/admin/settings";
 import About from "@/pages/about";
 import FAQ from "@/pages/faq";
 import Claims from "@/pages/claims";
@@ -47,6 +48,7 @@ function Router() {
       <Route path="/admin/claims/:id" component={AdminClaimDetail} />
       <Route path="/admin/claims" component={AdminClaims} />
       <Route path="/admin/users" component={AdminUsers} />
+      <Route path="/admin/settings" component={AdminSettings} />
       <Route path="/admin" component={AdminDashboard} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/components/admin-nav.tsx
+++ b/client/src/components/admin-nav.tsx
@@ -25,6 +25,9 @@ export default function AdminNav() {
             <Link href="/admin/users" className="text-gray-700 hover:text-primary">
               Users
             </Link>
+            <Link href="/admin/settings" className="text-gray-700 hover:text-primary">
+              Branding
+            </Link>
           </div>
           <div className="text-sm text-gray-600">
             Logged in as: {username}{" "}

--- a/client/src/components/logo.tsx
+++ b/client/src/components/logo.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import { cn } from "@/lib/utils";
+import { useBranding } from "@/hooks/use-branding";
 
 interface LogoProps {
   className?: string;
@@ -15,40 +17,61 @@ export function Logo({
   titleClassName,
   subtitleClassName,
 }: LogoProps) {
+  const { data } = useBranding();
+  const logoUrl = useMemo(() => {
+    const value = data?.data?.logoUrl;
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+  }, [data]);
+
   return (
     <div className={cn("flex items-center gap-3", className)}>
-      <svg
-        viewBox="0 0 320 120"
-        role="img"
-        aria-labelledby="bh-logo-title bh-logo-desc"
-        className="h-12 w-auto"
-      >
-        <title id="bh-logo-title">BH Auto Protect</title>
-        <desc id="bh-logo-desc">Stylized car silhouette above a shield with a checkmark</desc>
-        <defs>
-          <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#0F172A" />
-            <stop offset="50%" stopColor="#1D4ED8" />
-            <stop offset="100%" stopColor="#0F172A" />
-          </linearGradient>
-        </defs>
-        <g fill="none" stroke="url(#logoGradient)" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M30 66c20-22 60-40 110-40s86 16 120 40" />
-          <path d="M36 58c12-16 48-30 104-30s96 14 116 30" opacity="0.65" />
-        </g>
-        <g transform="translate(210 50)">
-          <path
-            d="M36 4 18-4 0 4v30c0 16 8 30 18 38 10-8 18-22 18-38V4Z"
-            fill="#0F172A"
-            opacity="0.12"
-          />
-          <path
-            d="M36 0 18-8 0 0v32c0 16 8 30 18 38 10-8 18-22 18-38V0Z"
-            fill="#0B1F4E"
-          />
-          <path d="M9 16 18 26l15-18" stroke="#E0F2FE" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round" />
-        </g>
-      </svg>
+      {logoUrl ? (
+        <img
+          src={logoUrl}
+          alt="BH Auto Protect logo"
+          className="h-12 w-auto object-contain"
+          loading="lazy"
+        />
+      ) : (
+        <svg
+          viewBox="0 0 320 120"
+          role="img"
+          aria-labelledby="bh-logo-title bh-logo-desc"
+          className="h-12 w-auto"
+        >
+          <title id="bh-logo-title">BH Auto Protect</title>
+          <desc id="bh-logo-desc">Stylized car silhouette above a shield with a checkmark</desc>
+          <defs>
+            <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stopColor="#0F172A" />
+              <stop offset="50%" stopColor="#1D4ED8" />
+              <stop offset="100%" stopColor="#0F172A" />
+            </linearGradient>
+          </defs>
+          <g fill="none" stroke="url(#logoGradient)" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M30 66c20-22 60-40 110-40s86 16 120 40" />
+            <path d="M36 58c12-16 48-30 104-30s96 14 116 30" opacity="0.65" />
+          </g>
+          <g transform="translate(210 50)">
+            <path
+              d="M36 4 18-4 0 4v30c0 16 8 30 18 38 10-8 18-22 18-38V4Z"
+              fill="#0F172A"
+              opacity="0.12"
+            />
+            <path
+              d="M36 0 18-8 0 0v32c0 16 8 30 18 38 10-8 18-22 18-38V0Z"
+              fill="#0B1F4E"
+            />
+            <path
+              d="M9 16 18 26l15-18"
+              stroke="#E0F2FE"
+              strokeWidth="6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </g>
+        </svg>
+      )}
       {showText && (
         <div className={cn("flex flex-col leading-tight", textClassName)}>
           <span

--- a/client/src/hooks/use-branding.ts
+++ b/client/src/hooks/use-branding.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+
+type BrandingResponse = {
+  data?: {
+    logoUrl: string | null;
+  };
+};
+
+export function useBranding() {
+  return useQuery<BrandingResponse>({
+    queryKey: ["/api/branding"],
+    queryFn: async () => {
+      const response = await fetch("/api/branding");
+      if (!response.ok) {
+        throw new Error("Failed to load branding");
+      }
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -1,0 +1,309 @@
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Image as ImageIcon } from "lucide-react";
+import AdminNav from "@/components/admin-nav";
+import AdminLogin from "@/components/admin-login";
+import { useAdminAuth } from "@/hooks/use-admin-auth";
+import { clearCredentials, fetchWithAuth } from "@/lib/auth";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
+const ACCEPTED_TYPES = ["image/jpeg", "image/pjpeg"];
+
+type BrandingResponse = {
+  data?: {
+    logoUrl: string | null;
+  };
+};
+
+type BrandingUploadResponse = BrandingResponse;
+
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        reject(new Error("Unable to read file."));
+        return;
+      }
+      const base64 = result.includes(",") ? result.split(",").pop() ?? "" : result;
+      if (!base64) {
+        reject(new Error("Unable to read file."));
+        return;
+      }
+      resolve(base64);
+    };
+    reader.onerror = () => reject(new Error("Unable to read file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function AdminSettings() {
+  const { authenticated, checking, markAuthenticated, markLoggedOut } = useAdminAuth();
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const queryClient = useQueryClient();
+  const queriesEnabled = authenticated && !checking;
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  const brandingQuery = useQuery<BrandingResponse>({
+    queryKey: ["/api/admin/branding"],
+    queryFn: async () => {
+      const response = await fetchWithAuth("/api/admin/branding");
+      if (response.status === 401) {
+        clearCredentials();
+        markLoggedOut();
+        throw new Error("Unauthorized");
+      }
+      if (!response.ok) {
+        throw new Error("Failed to load branding");
+      }
+      return response.json();
+    },
+    enabled: queriesEnabled,
+    staleTime: 0,
+  });
+
+  const uploadMutation = useMutation<BrandingUploadResponse, Error, File>({
+    mutationFn: async (file: File) => {
+      let base64: string;
+      try {
+        base64 = await fileToBase64(file);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to read file.";
+        throw new Error(message);
+      }
+
+      const response = await fetchWithAuth("/api/admin/branding/logo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          data: base64,
+          fileName: file.name,
+          mimeType: file.type || "image/jpeg",
+        }),
+      });
+
+      if (response.status === 401) {
+        clearCredentials();
+        markLoggedOut();
+        throw new Error("Unauthorized");
+      }
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.message === "string" ? payload.message : "Failed to upload logo";
+        throw new Error(message);
+      }
+
+      return response.json();
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["/api/admin/branding"], data);
+      queryClient.invalidateQueries({ queryKey: ["/api/branding"] });
+      setSelectedFile(null);
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+      setPreviewUrl(null);
+      setValidationError(null);
+      setUploadError(null);
+      setSuccessMessage("Logo updated successfully.");
+    },
+    onError: (error) => {
+      setUploadError(error.message);
+      setSuccessMessage(null);
+    },
+  });
+
+  const currentLogoUrl = useMemo(() => {
+    const value = brandingQuery.data?.data?.logoUrl;
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+  }, [brandingQuery.data]);
+
+  const displayedPreview = previewUrl ?? currentLogoUrl ?? null;
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    setSuccessMessage(null);
+    setUploadError(null);
+
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(null);
+    }
+
+    if (!file) {
+      setSelectedFile(null);
+      setValidationError(null);
+      return;
+    }
+
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      setSelectedFile(null);
+      setValidationError("Please upload a JPG image file.");
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setSelectedFile(null);
+      setValidationError("Logo must be 2MB or smaller.");
+      return;
+    }
+
+    setValidationError(null);
+    setSelectedFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedFile) {
+      setValidationError("Please choose a JPG logo before saving.");
+      return;
+    }
+
+    setValidationError(null);
+    setUploadError(null);
+    uploadMutation.mutate(selectedFile);
+  };
+
+  const handleClearSelection = () => {
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setPreviewUrl(null);
+    setSelectedFile(null);
+    setValidationError(null);
+    setUploadError(null);
+    setSuccessMessage(null);
+  };
+
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={markAuthenticated} />;
+  }
+
+  if (brandingQuery.isLoading && !brandingQuery.data) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminNav />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ImageIcon className="h-5 w-5 text-primary" />
+              Site Branding
+            </CardTitle>
+            <CardDescription>
+              Upload a JPG logo to replace the default illustration shown across the public site.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-8 lg:grid-cols-[240px_1fr]">
+              <div className="space-y-4">
+                <div className="flex flex-col items-center gap-3">
+                  <div className="w-full max-w-[220px] aspect-square rounded-lg border bg-white flex items-center justify-center overflow-hidden p-4">
+                    {displayedPreview ? (
+                      <img
+                        src={displayedPreview}
+                        alt="Current logo preview"
+                        className="max-h-full w-full object-contain"
+                      />
+                    ) : (
+                      <div className="text-center text-sm text-muted-foreground">No logo uploaded yet</div>
+                    )}
+                  </div>
+                  {currentLogoUrl && (
+                    <p className="text-xs text-muted-foreground break-words text-center">
+                      Live file: {currentLogoUrl}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <form className="space-y-6" onSubmit={handleSubmit}>
+                <div className="space-y-2">
+                  <Label htmlFor="logo">Logo image</Label>
+                  <Input
+                    id="logo"
+                    type="file"
+                    accept=".jpg,.jpeg,image/jpeg"
+                    onChange={handleFileChange}
+                    disabled={uploadMutation.isPending}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Upload a high-resolution JPG (max 2MB). We recommend at least 320×120 pixels with transparent or solid
+                    background.
+                  </p>
+                </div>
+
+                {validationError && (
+                  <Alert variant="destructive">
+                    <AlertTitle>Unable to use this file</AlertTitle>
+                    <AlertDescription>{validationError}</AlertDescription>
+                  </Alert>
+                )}
+
+                {uploadError && (
+                  <Alert variant="destructive">
+                    <AlertTitle>Upload failed</AlertTitle>
+                    <AlertDescription>{uploadError}</AlertDescription>
+                  </Alert>
+                )}
+
+                {successMessage && (
+                  <Alert>
+                    <AlertTitle>Logo updated</AlertTitle>
+                    <AlertDescription>{successMessage}</AlertDescription>
+                  </Alert>
+                )}
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button type="submit" disabled={uploadMutation.isPending}>
+                    {uploadMutation.isPending ? "Uploading…" : "Save logo"}
+                  </Button>
+                  {selectedFile && (
+                    <Button type="button" variant="outline" onClick={handleClearSelection} disabled={uploadMutation.isPending}>
+                      Cancel selection
+                    </Button>
+                  )}
+                </div>
+              </form>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,8 +6,8 @@ import { setupVite, serveStatic, log } from "./vite";
 const app = express();
 
 // Middleware
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: "5mb" }));
+app.use(express.urlencoded({ extended: true, limit: "5mb" }));
 
 async function startServer() {
   const server = await registerRoutes(app);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -162,6 +162,12 @@ export const emailTemplates = pgTable("email_templates", {
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
+export const siteSettings = pgTable("site_settings", {
+  key: varchar("key", { length: 120 }).primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
 // Relations
 export const leadsRelations = relations(leads, ({ one, many }) => ({
   vehicle: one(vehicles),
@@ -270,6 +276,10 @@ export const insertEmailTemplateSchema = createInsertSchema(emailTemplates).omit
   updatedAt: true,
 });
 
+export const insertSiteSettingSchema = createInsertSchema(siteSettings).omit({
+  updatedAt: true,
+});
+
 // Types
 export type Lead = typeof leads.$inferSelect;
 export type InsertLead = z.infer<typeof insertLeadSchema>;
@@ -291,3 +301,5 @@ export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type EmailTemplate = typeof emailTemplates.$inferSelect;
 export type InsertEmailTemplate = z.infer<typeof insertEmailTemplateSchema>;
+export type SiteSetting = typeof siteSettings.$inferSelect;
+export type InsertSiteSetting = z.infer<typeof insertSiteSettingSchema>;


### PR DESCRIPTION
## Summary
- add an admin branding settings page with validation, preview, and base64 logo uploads
- persist the uploaded logo path in a new site settings table and expose public/admin branding endpoints
- serve the uploaded logo across the site via a shared hook and expand server JSON limits for the upload payload

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caa652b4f08330b9ccf06bb8e8b7ae