### PR TITLE
Add support for basic plan type

### DIFF
--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -83,21 +83,27 @@ export const US_STATES = [
   { value: 'WY', label: 'Wyoming' },
 ];
 
+const CORE_PLAN_FEATURES = [
+  'Engine',
+  'Transmission',
+  'Cooling System',
+  'Brake System',
+  'Electrical System',
+  'Drive Axle',
+  'Trip Interruption',
+  'Gas Refill',
+  'Roadside Assistance',
+  'Rental Car',
+] as const;
+
 export const COVERAGE_PLANS = {
+  basic: {
+    name: 'Basic',
+    features: CORE_PLAN_FEATURES,
+  },
   bronze: {
     name: 'Bronze',
-    features: [
-      'Engine',
-      'Transmission',
-      'Cooling System',
-      'Brake System',
-      'Electrical System',
-      'Drive Axle',
-      'Trip Interruption',
-      'Gas Refill',
-      'Roadside Assistance',
-      'Rental Car',
-    ],
+    features: CORE_PLAN_FEATURES,
   },
   gold: {
     name: 'Gold',
@@ -146,7 +152,7 @@ export const COVERAGE_PLANS = {
     ],
   },
 } satisfies Record<
-  'bronze' | 'gold' | 'silver',
+  'basic' | 'bronze' | 'gold' | 'silver',
   {
     name: string;
     features: readonly string[];

--- a/client/src/lib/pricing.ts
+++ b/client/src/lib/pricing.ts
@@ -6,7 +6,7 @@ export interface VehicleInfo {
 }
 
 export interface CoverageInfo {
-  plan: "bronze" | "silver" | "gold";
+  plan: "basic" | "bronze" | "silver" | "gold";
   deductible: number;
 }
 
@@ -39,6 +39,7 @@ export function calculateQuote(
   // Base monthly price by coverage plan in dollars
   let basePrice = 0;
   switch (coverage.plan) {
+    case "basic":
     case "bronze":
       basePrice = 60;
       break;

--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -687,6 +687,7 @@ export default function AdminLeadDetail() {
                               <SelectValue placeholder="--- Please Select ---" />
                             </SelectTrigger>
                             <SelectContent>
+                              <SelectItem value="basic">Basic</SelectItem>
                               <SelectItem value="bronze">Bronze</SelectItem>
                               <SelectItem value="silver">Silver</SelectItem>
                               <SelectItem value="gold">Gold</SelectItem>
@@ -888,6 +889,7 @@ export default function AdminLeadDetail() {
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
+                          <SelectItem value="basic">Basic</SelectItem>
                           <SelectItem value="bronze">Bronze</SelectItem>
                           <SelectItem value="silver">Silver</SelectItem>
                           <SelectItem value="gold">Gold</SelectItem>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -332,7 +332,7 @@ export default function Landing() {
             <p className="text-xl text-gray-600 max-w-2xl mx-auto">Comprehensive coverage options for every budget</p>
           </div>
           <div className="grid lg:grid-cols-3 gap-8">
-            {["bronze", "gold", "silver"].map((tier, index) => {
+            {["basic", "silver", "gold"].map((tier, index) => {
               const plan = COVERAGE_PLANS[tier as keyof typeof COVERAGE_PLANS];
               const highlight = tier === "gold";
 

--- a/client/src/pages/plans.tsx
+++ b/client/src/pages/plans.tsx
@@ -21,19 +21,19 @@ export default function Plans() {
           Explore our plans and choose the level of protection that's right for you.
         </p>
         <div className="grid lg:grid-cols-3 gap-8">
-          {/* Bronze Plan */}
+          {/* Basic Plan */}
           <Card className="relative hover:shadow-lg transition-shadow">
             <CardContent className="p-8">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.bronze.name}</h3>
-                {COVERAGE_PLANS.bronze.description && (
+                <h3 className="text-2xl font-bold mb-2">{COVERAGE_PLANS.basic.name}</h3>
+                {COVERAGE_PLANS.basic.description && (
                   <p className="text-sm font-semibold text-primary">
-                    {COVERAGE_PLANS.bronze.description}
+                    {COVERAGE_PLANS.basic.description}
                   </p>
                 )}
               </div>
               <ul className="space-y-4 mb-8">
-                {COVERAGE_PLANS.bronze.features.map((feature) => (
+                {COVERAGE_PLANS.basic.features.map((feature) => (
                   <li key={feature} className="flex items-center">
                     <Check className="w-5 h-5 text-accent mr-3" />
                     <span>{feature}</span>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -799,7 +799,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           odometer: z.number(),
         }),
         coverage: z.object({
-          plan: z.enum(['bronze', 'silver', 'gold']),
+          plan: z.enum(['basic', 'bronze', 'silver', 'gold']),
           deductible: z.number(),
         }),
         location: z.object({
@@ -1006,7 +1006,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Assign coverage plan to a lead
   app.post('/api/leads/:id/coverage', async (req, res) => {
     const schema = z.object({
-      plan: z.enum(['bronze', 'silver', 'gold']),
+      plan: z.enum(['basic', 'bronze', 'silver', 'gold']),
       deductible: z.coerce.number(),
       termMonths: z.coerce.number().default(36),
       priceMonthly: z.coerce.number(),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
 // Enums
-export const planTypeEnum = pgEnum('plan_type', ['bronze', 'silver', 'gold']);
+export const planTypeEnum = pgEnum('plan_type', ['basic', 'bronze', 'silver', 'gold']);
 export const quoteStatusEnum = pgEnum('quote_status', ['draft', 'sent', 'accepted', 'rejected']);
 export const claimStatusEnum = pgEnum('claim_status', [
   'new',


### PR DESCRIPTION
## Summary
- add the "basic" plan value to the shared schema and server validation so database records parse correctly
- update shared pricing logic and coverage metadata to understand the new plan
- surface the Basic plan option throughout the marketing and admin interfaces

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caabae33a08330b8f336d57f191545