### PR TITLE
Add customer portal with authentication and account features

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ import Claims from "@/pages/claims";
 import Plans from "@/pages/plans";
 import Contact from "@/pages/contact";
 import ThankYou from "@/pages/thank-you";
+import CustomerPortal from "@/pages/portal";
 
 function Router() {
   return (
@@ -50,6 +51,8 @@ function Router() {
       <Route path="/admin/users" component={AdminUsers} />
       <Route path="/admin/settings" component={AdminSettings} />
       <Route path="/admin" component={AdminDashboard} />
+      <Route path="/portal" component={CustomerPortal} />
+      <Route path="/portal/:rest*" component={CustomerPortal} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -58,6 +58,7 @@ export default function Footer() {
               <li><a href="/claims" className="hover:text-white">File a Claim</a></li>
               <li><a href="/contact" className="hover:text-white">Customer Support</a></li>
               <li><a href="/faq" className="hover:text-white">FAQ</a></li>
+              <li><a href="/portal" className="hover:text-white">Customer Portal</a></li>
             </ul>
           </div>
           <div>

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -21,6 +21,7 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
     { href: "/about", label: "About" },
     { href: "/faq", label: "FAQ" },
     { href: "/claims", label: "Claims" },
+    { href: "/portal", label: "Customer Portal" },
   ];
 
   return (

--- a/client/src/lib/customer-auth.ts
+++ b/client/src/lib/customer-auth.ts
@@ -1,0 +1,273 @@
+export type CustomerAccount = {
+  id: string;
+  email: string;
+  displayName?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  lastLoginAt?: string | null;
+};
+
+export type CustomerPolicy = {
+  id: string;
+  leadId: string;
+  package: string | null;
+  expirationMiles: number | null;
+  expirationDate: string | null;
+  deductible: number | null;
+  totalPremium: number | null;
+  downPayment: number | null;
+  policyStartDate: string | null;
+  monthlyPayment: number | null;
+  totalPayments: number | null;
+  createdAt: string | null;
+  lead: {
+    id?: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    state?: string | null;
+    zip?: string | null;
+  } | null;
+  vehicle: {
+    id?: string;
+    year?: number | null;
+    make?: string | null;
+    model?: string | null;
+    trim?: string | null;
+    vin?: string | null;
+    odometer?: number | null;
+  } | null;
+};
+
+export type CustomerClaim = {
+  id: string;
+  policyId: string | null;
+  status: string;
+  nextEstimate: string | null;
+  nextPayment: string | null;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  message: string;
+  claimReason?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CustomerPaymentProfile = {
+  id: string;
+  customerId: string;
+  policyId: string;
+  paymentMethod: string | null;
+  accountName: string | null;
+  accountIdentifier: string | null;
+  autopayEnabled: boolean;
+  notes: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+};
+
+type StoredSession = {
+  email: string | null;
+  displayName?: string | null;
+};
+
+const STORAGE_KEY = "customerPortalAuth";
+
+function readStoredSession(): StoredSession {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { email: null, displayName: null };
+    }
+    const parsed = JSON.parse(raw) as StoredSession;
+    return {
+      email: typeof parsed.email === "string" ? parsed.email : null,
+      displayName: typeof parsed.displayName === "string" ? parsed.displayName : null,
+    };
+  } catch {
+    return { email: null, displayName: null };
+  }
+}
+
+function storeSession(email: string, displayName?: string | null) {
+  const payload: StoredSession = {
+    email,
+    displayName: displayName ?? null,
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+function clearStoredSession() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function getStoredCustomerEmail(): string | null {
+  return readStoredSession().email;
+}
+
+export function getStoredCustomerName(): string | null {
+  return readStoredSession().displayName ?? null;
+}
+
+export type CustomerSessionSnapshot = {
+  customer: CustomerAccount;
+  policies: CustomerPolicy[];
+};
+
+type AuthSuccess = {
+  success: true;
+  customer: CustomerAccount;
+  policies: CustomerPolicy[];
+};
+
+type AuthFailure = {
+  success: false;
+  message: string;
+};
+
+export type AuthResult = AuthSuccess | AuthFailure;
+
+type Credentials = {
+  email: string;
+  password: string;
+};
+
+export type RegistrationPayload = Credentials & {
+  policyId: string;
+  displayName?: string;
+};
+
+function mapAuthResponse(data: unknown): AuthSuccess | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const payload = (data as { customer?: unknown; policies?: unknown }).customer;
+  const policies = (data as { policies?: unknown }).policies;
+
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const customer = payload as CustomerAccount;
+  if (!customer || typeof customer.email !== "string") {
+    return null;
+  }
+
+  return {
+    success: true,
+    customer,
+    policies: Array.isArray(policies) ? (policies as CustomerPolicy[]) : [],
+  } as AuthSuccess;
+}
+
+async function handleAuthRequest(
+  endpoint: string,
+  payload: Record<string, unknown>,
+): Promise<AuthResult> {
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    });
+
+    const json = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      const message =
+        typeof (json as { message?: unknown }).message === "string"
+          ? (json as { message: string }).message
+          : "Unable to complete the request.";
+      return { success: false, message };
+    }
+
+    const mapped = mapAuthResponse((json as { data?: unknown }).data);
+    if (!mapped) {
+      return { success: false, message: "Unexpected response from server." };
+    }
+
+    storeSession(mapped.customer.email, mapped.customer.displayName ?? null);
+    return mapped;
+  } catch {
+    return { success: false, message: "Unable to reach the server. Please try again." };
+  }
+}
+
+export async function registerCustomer(payload: RegistrationPayload): Promise<AuthResult> {
+  return handleAuthRequest("/api/customer/register", payload);
+}
+
+export async function loginCustomer(payload: Credentials): Promise<AuthResult> {
+  return handleAuthRequest("/api/customer/login", payload);
+}
+
+export async function checkCustomerSession(): Promise<CustomerSessionSnapshot | null> {
+  try {
+    const response = await fetch("/api/customer/session", {
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        clearStoredSession();
+      }
+      return null;
+    }
+
+    const json = await response.json().catch(() => ({}));
+    const data = (json as { data?: unknown }).data;
+    if (!data || typeof data !== "object") {
+      return null;
+    }
+
+    const authenticated = (data as { authenticated?: unknown }).authenticated;
+    if (!authenticated) {
+      return null;
+    }
+
+    const mapped = mapAuthResponse(data);
+    if (!mapped) {
+      return null;
+    }
+
+    storeSession(mapped.customer.email, mapped.customer.displayName ?? null);
+    return { customer: mapped.customer, policies: mapped.policies };
+  } catch {
+    return null;
+  }
+}
+
+export async function logoutCustomer(): Promise<void> {
+  clearStoredSession();
+  try {
+    await fetch("/api/customer/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+  } catch {
+    // ignore network errors during logout
+  }
+}
+
+export async function fetchCustomerJson<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers ?? {}),
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || response.statusText);
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/client/src/pages/portal/auth.tsx
+++ b/client/src/pages/portal/auth.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  loginCustomer,
+  registerCustomer,
+  type AuthResult,
+  type CustomerSessionSnapshot,
+} from "@/lib/customer-auth";
+import { useToast } from "@/hooks/use-toast";
+
+type Props = {
+  onAuthenticated: (session: CustomerSessionSnapshot) => void;
+};
+
+function isSuccess(result: AuthResult): result is Extract<AuthResult, { success: true }> {
+  return result.success;
+}
+
+export default function CustomerPortalAuth({ onAuthenticated }: Props) {
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<"login" | "register">("login");
+  const [loading, setLoading] = useState(false);
+  const [loginForm, setLoginForm] = useState({ email: "", password: "" });
+  const [registerForm, setRegisterForm] = useState({
+    email: "",
+    password: "",
+    confirmPassword: "",
+    policyId: "",
+    displayName: "",
+  });
+
+  const handleLogin = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    const result = await loginCustomer(loginForm);
+    setLoading(false);
+
+    if (isSuccess(result)) {
+      toast({
+        title: "Welcome back",
+        description: "You are now signed in to your policy portal.",
+      });
+      onAuthenticated({ customer: result.customer, policies: result.policies });
+    } else {
+      toast({ title: "Login failed", description: result.message, variant: "destructive" });
+    }
+  };
+
+  const handleRegister = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (registerForm.password !== registerForm.confirmPassword) {
+      toast({ title: "Passwords do not match", variant: "destructive" });
+      return;
+    }
+
+    setLoading(true);
+    const result = await registerCustomer({
+      email: registerForm.email,
+      password: registerForm.password,
+      policyId: registerForm.policyId,
+      displayName: registerForm.displayName || undefined,
+    });
+    setLoading(false);
+
+    if (isSuccess(result)) {
+      toast({
+        title: "Account created",
+        description: "Your customer portal is ready to use.",
+      });
+      onAuthenticated({ customer: result.customer, policies: result.policies });
+    } else {
+      toast({ title: "Registration failed", description: result.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center px-4 py-16">
+      <Card className="w-full max-w-2xl shadow-2xl border-slate-700 bg-slate-900/90 backdrop-blur">
+        <CardHeader className="text-center space-y-2">
+          <CardTitle className="text-3xl font-bold text-white">BH Auto Protect Portal</CardTitle>
+          <p className="text-slate-300 text-sm">
+            Access your coverage documents, submit claims, and keep your payment preferences up to date.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
+            <TabsList className="grid grid-cols-2 mb-6">
+              <TabsTrigger value="login">Sign In</TabsTrigger>
+              <TabsTrigger value="register">Create Account</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="login">
+              <form onSubmit={handleLogin} className="space-y-4">
+                <div className="space-y-2">
+                  <Label className="text-slate-200" htmlFor="login-email">
+                    Email
+                  </Label>
+                  <Input
+                    id="login-email"
+                    type="email"
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    value={loginForm.email}
+                    onChange={(event) => setLoginForm({ ...loginForm, email: event.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-200" htmlFor="login-password">
+                    Password
+                  </Label>
+                  <Input
+                    id="login-password"
+                    type="password"
+                    autoComplete="current-password"
+                    value={loginForm.password}
+                    onChange={(event) => setLoginForm({ ...loginForm, password: event.target.value })}
+                  />
+                </div>
+                <Button type="submit" className="w-full" disabled={loading}>
+                  {loading ? "Signing in..." : "Sign In"}
+                </Button>
+              </form>
+            </TabsContent>
+
+            <TabsContent value="register">
+              <form onSubmit={handleRegister} className="space-y-4">
+                <div className="grid md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label className="text-slate-200" htmlFor="register-email">
+                      Email
+                    </Label>
+                    <Input
+                      id="register-email"
+                      type="email"
+                      placeholder="you@example.com"
+                      value={registerForm.email}
+                      onChange={(event) => setRegisterForm({ ...registerForm, email: event.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-slate-200" htmlFor="register-policy">
+                      Policy Number
+                    </Label>
+                    <Input
+                      id="register-policy"
+                      placeholder="Enter your policy ID"
+                      value={registerForm.policyId}
+                      onChange={(event) => setRegisterForm({ ...registerForm, policyId: event.target.value })}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-200" htmlFor="register-display-name">
+                    Preferred Display Name (optional)
+                  </Label>
+                  <Input
+                    id="register-display-name"
+                    placeholder="How should we address you?"
+                    value={registerForm.displayName}
+                    onChange={(event) => setRegisterForm({ ...registerForm, displayName: event.target.value })}
+                  />
+                </div>
+                <div className="grid md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label className="text-slate-200" htmlFor="register-password">
+                      Password
+                    </Label>
+                    <Input
+                      id="register-password"
+                      type="password"
+                      autoComplete="new-password"
+                      value={registerForm.password}
+                      onChange={(event) => setRegisterForm({ ...registerForm, password: event.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-slate-200" htmlFor="register-confirm">
+                      Confirm Password
+                    </Label>
+                    <Input
+                      id="register-confirm"
+                      type="password"
+                      autoComplete="new-password"
+                      value={registerForm.confirmPassword}
+                      onChange={(event) => setRegisterForm({ ...registerForm, confirmPassword: event.target.value })}
+                    />
+                  </div>
+                </div>
+                <Button type="submit" className="w-full" disabled={loading}>
+                  {loading ? "Creating account..." : "Create Account"}
+                </Button>
+              </form>
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/portal/claims.tsx
+++ b/client/src/pages/portal/claims.tsx
@@ -1,0 +1,281 @@
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  fetchCustomerJson,
+  type CustomerSessionSnapshot,
+  type CustomerPolicy,
+  type CustomerClaim,
+} from "@/lib/customer-auth";
+import { useToast } from "@/hooks/use-toast";
+
+type Props = {
+  session: CustomerSessionSnapshot;
+};
+
+type ClaimFormState = {
+  policyId: string;
+  claimReason: string;
+  message: string;
+  preferredPhone: string;
+  currentOdometer: string;
+};
+
+const initialForm: ClaimFormState = {
+  policyId: "",
+  claimReason: "",
+  message: "",
+  preferredPhone: "",
+  currentOdometer: "",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return value;
+  return dateFormatter.format(date);
+}
+
+function describePolicy(policy: CustomerPolicy): string {
+  const vehicle = policy.vehicle;
+  if (!vehicle) return `Policy ${policy.id}`;
+  const parts = [vehicle.year ?? undefined, vehicle.make ?? undefined, vehicle.model ?? undefined]
+    .map((part) => (part == null ? "" : String(part)))
+    .filter(Boolean);
+  const summary = parts.join(" ");
+  return summary ? `${summary} · ${policy.id}` : `Policy ${policy.id}`;
+}
+
+function normalizeNumberInput(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed.replace(/,/g, ""));
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function statusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+  switch (status) {
+    case "denied":
+      return "destructive";
+    case "claim_covered_closed":
+      return "secondary";
+    case "awaiting_customer_action":
+      return "outline";
+    default:
+      return "default";
+  }
+}
+
+function formatStatus(status: string): string {
+  return status.replace(/_/g, " ");
+}
+
+export default function CustomerPortalClaims({ session }: Props) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<ClaimFormState>(initialForm);
+
+  const policiesQuery = useQuery<{ data?: { policies?: CustomerPolicy[] } }>([
+    "/api/customer/policies",
+  ]);
+  const claimsQuery = useQuery<{ data?: { claims?: CustomerClaim[] } }>([
+    "/api/customer/claims",
+  ]);
+
+  const policies = useMemo(() => {
+    const apiPolicies = policiesQuery.data?.data?.policies;
+    if (Array.isArray(apiPolicies) && apiPolicies.length > 0) {
+      return apiPolicies;
+    }
+    return session.policies;
+  }, [policiesQuery.data, session.policies]);
+
+  const claims = useMemo(() => claimsQuery.data?.data?.claims ?? [], [claimsQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const payload: Record<string, unknown> = {
+        policyId: form.policyId,
+        message: form.message.trim(),
+      };
+      if (form.claimReason.trim()) {
+        payload.claimReason = form.claimReason.trim();
+      }
+      if (form.preferredPhone.trim()) {
+        payload.preferredPhone = form.preferredPhone.trim();
+      }
+      const odometer = normalizeNumberInput(form.currentOdometer);
+      if (odometer !== undefined) {
+        payload.currentOdometer = odometer;
+      }
+
+      return fetchCustomerJson<{ data: CustomerClaim }>("/api/customer/claims", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    },
+    onSuccess: () => {
+      toast({
+        title: "Claim submitted",
+        description: "Our claims team will reach out shortly with next steps.",
+      });
+      setForm(initialForm);
+      void queryClient.invalidateQueries(["/api/customer/claims"]);
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : "We couldn’t submit your claim.";
+      toast({ title: "Submission failed", description: message, variant: "destructive" });
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!form.policyId) {
+      toast({ title: "Select a policy", description: "Choose the policy you need help with." });
+      return;
+    }
+    if (!form.message.trim()) {
+      toast({ title: "Describe the issue", description: "Let us know what happened." });
+      return;
+    }
+    mutation.mutate();
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-slate-900">Claims Center</h1>
+        <p className="text-slate-600 mt-2">
+          Tell us what happened and we’ll coordinate the repairs, logistics, and next steps for you.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Start a New Claim</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="policy">Covered vehicle</Label>
+              <Select
+                value={form.policyId}
+                onValueChange={(value) => setForm((current) => ({ ...current, policyId: value }))}
+                disabled={policies.length === 0}
+              >
+                <SelectTrigger id="policy">
+                  <SelectValue placeholder={policies.length === 0 ? "No policies available" : "Select a policy"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {policies.map((policy) => (
+                    <SelectItem key={policy.id} value={policy.id}>
+                      {describePolicy(policy)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="summary">What happened?</Label>
+                <Input
+                  id="summary"
+                  placeholder="Transmission issues, warning lights, noise..."
+                  value={form.claimReason}
+                  onChange={(event) => setForm((current) => ({ ...current, claimReason: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="phone">Preferred phone</Label>
+                <Input
+                  id="phone"
+                  placeholder="Where can we reach you?"
+                  value={form.preferredPhone}
+                  onChange={(event) => setForm((current) => ({ ...current, preferredPhone: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="details">Details for our claims team</Label>
+              <Textarea
+                id="details"
+                rows={5}
+                placeholder="Tell us when the issue started, what you were doing, and anything else we should know."
+                value={form.message}
+                onChange={(event) => setForm((current) => ({ ...current, message: event.target.value }))}
+              />
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="odometer">Current odometer (optional)</Label>
+                <Input
+                  id="odometer"
+                  inputMode="numeric"
+                  placeholder="eg. 82,350"
+                  value={form.currentOdometer}
+                  onChange={(event) => setForm((current) => ({ ...current, currentOdometer: event.target.value }))}
+                />
+              </div>
+            </div>
+            <Button type="submit" disabled={mutation.isLoading || policies.length === 0}>
+              {mutation.isLoading ? "Submitting..." : "Submit Claim"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Claims</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {claimsQuery.isLoading ? (
+            <Skeleton className="h-24 w-full" />
+          ) : claims.length === 0 ? (
+            <p className="text-sm text-slate-500">You haven’t filed any claims yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Claim</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Filed</TableHead>
+                  <TableHead>Last update</TableHead>
+                  <TableHead>Notes</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {claims.map((claim) => (
+                  <TableRow key={claim.id}>
+                    <TableCell className="font-medium">#{claim.id}</TableCell>
+                    <TableCell>
+                      <Badge variant={statusVariant(claim.status)} className="capitalize">
+                        {formatStatus(claim.status)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{formatDate(claim.createdAt)}</TableCell>
+                    <TableCell>{formatDate(claim.updatedAt)}</TableCell>
+                    <TableCell className="max-w-xs text-sm text-slate-600 line-clamp-3">{claim.message}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/portal/index.tsx
+++ b/client/src/pages/portal/index.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, Route, Switch, useLocation } from "wouter";
+import { Button } from "@/components/ui/button";
+import CustomerPortalAuth from "./auth";
+import CustomerPortalOverview from "./overview";
+import CustomerPortalClaims from "./claims";
+import CustomerPortalPayments from "./payments";
+import CustomerPortalPolicyRequest from "./policy-request";
+import {
+  checkCustomerSession,
+  logoutCustomer,
+  type CustomerSessionSnapshot,
+} from "@/lib/customer-auth";
+
+const NAV_LINKS = [
+  { href: "/portal", label: "Overview" },
+  { href: "/portal/claims", label: "Claims" },
+  { href: "/portal/payments", label: "Payments" },
+  { href: "/portal/policies/new", label: "Add Coverage" },
+];
+
+function LoadingState() {
+  return (
+    <div className="min-h-screen bg-slate-100 flex items-center justify-center px-4">
+      <div className="space-y-4 text-center">
+        <div className="mx-auto h-12 w-12 rounded-full border-4 border-primary border-t-transparent animate-spin" />
+        <p className="text-sm text-slate-500">Preparing your portal...</p>
+      </div>
+    </div>
+  );
+}
+
+export default function CustomerPortal() {
+  const [session, setSession] = useState<CustomerSessionSnapshot | null | undefined>(undefined);
+  const [location] = useLocation();
+
+  useEffect(() => {
+    let mounted = true;
+    checkCustomerSession()
+      .then((snapshot) => {
+        if (mounted) {
+          setSession(snapshot);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setSession(null);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleAuthenticated = (snapshot: CustomerSessionSnapshot) => {
+    setSession(snapshot);
+  };
+
+  const handleLogout = async () => {
+    await logoutCustomer();
+    setSession(null);
+  };
+
+  const isActiveLink = (href: string) => {
+    if (!location) return false;
+    if (href === "/portal") {
+      return location === "/portal" || location === "/portal/";
+    }
+    return location.startsWith(href);
+  };
+
+  const displayName = useMemo(() => {
+    if (!session?.customer) return "";
+    const { displayName: name, email } = session.customer;
+    return name && name.trim() ? name.trim() : email;
+  }, [session]);
+
+  if (session === undefined) {
+    return <LoadingState />;
+  }
+
+  if (!session) {
+    return <CustomerPortalAuth onAuthenticated={handleAuthenticated} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <header className="bg-slate-900 text-white shadow">
+        <div className="max-w-6xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">BH Auto Protect</p>
+            <h1 className="text-2xl font-semibold">Customer Portal</h1>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="text-right text-sm text-slate-300">
+              <p className="font-medium text-white">{displayName}</p>
+              {session.customer.displayName && session.customer.displayName !== session.customer.email ? (
+                <p>{session.customer.email}</p>
+              ) : null}
+            </div>
+            <Button variant="outline" onClick={handleLogout} className="bg-white/10 hover:bg-white/20">
+              Sign out
+            </Button>
+          </div>
+        </div>
+        <nav className="bg-slate-800">
+          <div className="max-w-6xl mx-auto px-4 py-3 flex flex-wrap gap-2">
+            {NAV_LINKS.map((link) => (
+              <Link key={link.href} href={link.href} className="group">
+                <span
+                  className={`inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                    isActiveLink(link.href)
+                      ? "bg-white text-slate-900 shadow"
+                      : "text-slate-200 hover:text-white hover:bg-slate-700"
+                  }`}
+                >
+                  {link.label}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </nav>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 py-8">
+        <Switch>
+          <Route path="/portal">
+            <CustomerPortalOverview session={session} />
+          </Route>
+          <Route path="/portal/claims">
+            <CustomerPortalClaims session={session} />
+          </Route>
+          <Route path="/portal/payments">
+            <CustomerPortalPayments session={session} />
+          </Route>
+          <Route path="/portal/policies/new">
+            <CustomerPortalPolicyRequest session={session} />
+          </Route>
+          <Route>
+            <CustomerPortalOverview session={session} />
+          </Route>
+        </Switch>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/portal/overview.tsx
+++ b/client/src/pages/portal/overview.tsx
@@ -1,0 +1,244 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  type CustomerSessionSnapshot,
+  type CustomerPolicy,
+  type CustomerClaim,
+} from "@/lib/customer-auth";
+
+type Props = {
+  session: CustomerSessionSnapshot;
+};
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "To be scheduled";
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "To be scheduled";
+  return dateFormatter.format(date);
+}
+
+function summarizeVehicle(policy: CustomerPolicy): string {
+  const parts = [
+    policy.vehicle?.year ?? undefined,
+    policy.vehicle?.make ?? undefined,
+    policy.vehicle?.model ?? undefined,
+  ]
+    .map((part) => (part == null ? "" : String(part)))
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : "Vehicle details on file";
+}
+
+function friendlyPlanName(plan: string | null): string {
+  if (!plan) return "Vehicle Protection";
+  return plan.charAt(0).toUpperCase() + plan.slice(1);
+}
+
+function computeMonthlyTotal(policies: CustomerPolicy[]): number {
+  return policies.reduce((total, policy) => total + (policy.monthlyPayment ?? 0), 0);
+}
+
+function computeOpenClaims(claims: CustomerClaim[]): number {
+  return claims.filter((claim) => claim.status !== "claim_covered_closed").length;
+}
+
+export default function CustomerPortalOverview({ session }: Props) {
+  const policiesQuery = useQuery<{ data?: { policies?: CustomerPolicy[] } }>([
+    "/api/customer/policies",
+  ]);
+  const claimsQuery = useQuery<{ data?: { claims?: CustomerClaim[] } }>([
+    "/api/customer/claims",
+  ]);
+
+  const policies = useMemo(() => {
+    const apiPolicies = policiesQuery.data?.data?.policies;
+    if (Array.isArray(apiPolicies) && apiPolicies.length > 0) {
+      return apiPolicies;
+    }
+    return session.policies;
+  }, [policiesQuery.data, session.policies]);
+
+  const claims = useMemo(() => claimsQuery.data?.data?.claims ?? [], [claimsQuery.data]);
+
+  const monthlyTotal = computeMonthlyTotal(policies);
+  const activeClaims = computeOpenClaims(claims);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-slate-900">Welcome back</h1>
+        <p className="text-slate-600 mt-2">
+          Review your active coverage, keep an eye on open claims, and stay ahead of upcoming payments.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card className="border-primary/10 bg-white">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-slate-600">Active Policies</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {policiesQuery.isLoading ? (
+              <Skeleton className="h-8 w-16" />
+            ) : (
+              <p className="text-3xl font-semibold text-slate-900">{policies.length}</p>
+            )}
+            <p className="text-sm text-slate-500 mt-1">Coverage plans linked to your account</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border-amber-200 bg-amber-50/60">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-amber-700">Open Claims</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {claimsQuery.isLoading ? (
+              <Skeleton className="h-8 w-16" />
+            ) : (
+              <p className="text-3xl font-semibold text-amber-900">{activeClaims}</p>
+            )}
+            <p className="text-sm text-amber-700/80 mt-1">We’ll keep you updated every step of the way</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border-emerald-200 bg-emerald-50/70">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-emerald-700">Monthly Coverage</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {policiesQuery.isLoading ? (
+              <Skeleton className="h-8 w-24" />
+            ) : (
+              <p className="text-3xl font-semibold text-emerald-900">
+                {monthlyTotal > 0 ? currencyFormatter.format(monthlyTotal) : "—"}
+              </p>
+            )}
+            <p className="text-sm text-emerald-700/80 mt-1">Estimated monthly payment across all policies</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your Coverage Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {policiesQuery.isLoading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-20 w-full" />
+              <Skeleton className="h-20 w-full" />
+            </div>
+          ) : policies.length === 0 ? (
+            <p className="text-sm text-slate-500">
+              We haven’t linked any policies yet. If you recently purchased coverage, give us a day to finish the setup
+              or request access using the “Add Coverage” tab.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {policies.map((policy) => (
+                <div
+                  key={policy.id}
+                  className="border border-slate-200 rounded-xl p-4 md:p-6 bg-gradient-to-br from-white via-slate-50 to-white"
+                >
+                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                    <div>
+                      <h3 className="text-lg font-semibold text-slate-900">{summarizeVehicle(policy)}</h3>
+                      <p className="text-sm text-slate-500">
+                        Policy #{policy.id}
+                      </p>
+                    </div>
+                    <Badge className="w-fit" variant="secondary">
+                      {friendlyPlanName(policy.package)} Plan
+                    </Badge>
+                  </div>
+                  <div className="grid md:grid-cols-4 gap-4 mt-4 text-sm text-slate-600">
+                    <div>
+                      <p className="font-semibold text-slate-700">Coverage start</p>
+                      <p>{formatDate(policy.policyStartDate)}</p>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-slate-700">Expires</p>
+                      <p>{formatDate(policy.expirationDate)}</p>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-slate-700">Deductible</p>
+                      <p>{policy.deductible != null ? currencyFormatter.format(policy.deductible) : "On file"}</p>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-slate-700">Monthly payment</p>
+                      <p>
+                        {policy.monthlyPayment != null
+                          ? currencyFormatter.format(policy.monthlyPayment)
+                          : "On file"}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="mt-4 text-sm text-slate-500">
+                    <p>
+                      Questions about your coverage? Reach us anytime at{' '}
+                      <a className="text-primary font-medium" href="tel:18882001234">
+                        1 (888) 200-1234
+                      </a>{' '}
+                      or email{' '}
+                      <a className="text-primary font-medium" href="mailto:support@bhautoprotect.com">
+                        support@bhautoprotect.com
+                      </a>
+                      .
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Claim Activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {claimsQuery.isLoading ? (
+            <Skeleton className="h-24 w-full" />
+          ) : claims.length === 0 ? (
+            <p className="text-sm text-slate-500">
+              You don’t have any claims in progress. If your vehicle needs attention, head to the Claims tab to start a
+              new request.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {claims.slice(0, 3).map((claim) => (
+                <div key={claim.id} className="border border-slate-200 rounded-lg p-4">
+                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-800">Claim #{claim.id}</p>
+                      <p className="text-xs text-slate-500">Filed {formatDate(claim.createdAt)}</p>
+                    </div>
+                    <Badge variant="outline" className="capitalize">
+                      {claim.status.replace(/_/g, ' ')}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-slate-600 mt-3 line-clamp-2">{claim.message}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/portal/payments.tsx
+++ b/client/src/pages/portal/payments.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import {
+  fetchCustomerJson,
+  type CustomerSessionSnapshot,
+  type CustomerPolicy,
+  type CustomerPaymentProfile,
+} from "@/lib/customer-auth";
+import { useToast } from "@/hooks/use-toast";
+
+type Props = {
+  session: CustomerSessionSnapshot;
+};
+
+type PaymentFormState = {
+  paymentMethod: string;
+  accountName: string;
+  accountIdentifier: string;
+  autopayEnabled: boolean;
+  notes: string;
+};
+
+const initialForm: PaymentFormState = {
+  paymentMethod: "",
+  accountName: "",
+  accountIdentifier: "",
+  autopayEnabled: false,
+  notes: "",
+};
+
+function describePolicy(policy: CustomerPolicy): string {
+  const vehicle = policy.vehicle;
+  if (!vehicle) return `Policy ${policy.id}`;
+  const parts = [vehicle.year ?? undefined, vehicle.make ?? undefined, vehicle.model ?? undefined]
+    .map((part) => (part == null ? "" : String(part)))
+    .filter(Boolean);
+  const summary = parts.join(" ");
+  return summary ? `${summary} · ${policy.id}` : `Policy ${policy.id}`;
+}
+
+function PaymentCard({
+  policy,
+  profile,
+  onSave,
+  saving,
+}: {
+  policy: CustomerPolicy;
+  profile: CustomerPaymentProfile | undefined;
+  onSave: (form: PaymentFormState) => void;
+  saving: boolean;
+}) {
+  const [form, setForm] = useState<PaymentFormState>(initialForm);
+
+  useEffect(() => {
+    if (!profile) {
+      setForm(initialForm);
+      return;
+    }
+    setForm({
+      paymentMethod: profile.paymentMethod ?? "",
+      accountName: profile.accountName ?? "",
+      accountIdentifier: profile.accountIdentifier ?? "",
+      autopayEnabled: profile.autopayEnabled,
+      notes: profile.notes ?? "",
+    });
+  }, [profile]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onSave(form);
+  };
+
+  return (
+    <Card key={policy.id} className="border border-slate-200 shadow-sm">
+      <CardHeader>
+        <CardTitle className="text-lg text-slate-900">{describePolicy(policy)}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor={`method-${policy.id}`}>Payment method</Label>
+              <Input
+                id={`method-${policy.id}`}
+                placeholder="Visa ending in 1234, ACH, etc."
+                value={form.paymentMethod}
+                onChange={(event) => setForm((current) => ({ ...current, paymentMethod: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`name-${policy.id}`}>Name on account</Label>
+              <Input
+                id={`name-${policy.id}`}
+                placeholder="Who should we bill?"
+                value={form.accountName}
+                onChange={(event) => setForm((current) => ({ ...current, accountName: event.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`identifier-${policy.id}`}>Billing identifier</Label>
+            <Input
+              id={`identifier-${policy.id}`}
+              placeholder="Last four digits or billing reference"
+              value={form.accountIdentifier}
+              onChange={(event) => setForm((current) => ({ ...current, accountIdentifier: event.target.value }))}
+            />
+            <p className="text-xs text-slate-500">
+              We only store the last few digits of your payment details. A specialist will confirm the full information over
+              the phone before charging anything.
+            </p>
+          </div>
+          <div className="flex items-center justify-between rounded-lg border border-slate-200 p-3">
+            <div>
+              <p className="text-sm font-medium text-slate-800">Autopay</p>
+              <p className="text-xs text-slate-500">Enable recurring payments once everything is set up.</p>
+            </div>
+            <Switch
+              checked={form.autopayEnabled}
+              onCheckedChange={(checked) => setForm((current) => ({ ...current, autopayEnabled: checked }))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`notes-${policy.id}`}>Notes for our billing team</Label>
+            <Textarea
+              id={`notes-${policy.id}`}
+              rows={4}
+              placeholder="Share billing preferences, special instructions, or timing requests."
+              value={form.notes}
+              onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+            />
+          </div>
+          <Button type="submit" disabled={saving}>
+            {saving ? "Saving..." : "Save payment preferences"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function CustomerPortalPayments({ session }: Props) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const policiesQuery = useQuery<{ data?: { policies?: CustomerPolicy[] } }>([
+    "/api/customer/policies",
+  ]);
+  const paymentProfilesQuery = useQuery<{ data?: { paymentProfiles?: CustomerPaymentProfile[] } }>([
+    "/api/customer/payment-profiles",
+  ]);
+
+  const policies = useMemo(() => {
+    const apiPolicies = policiesQuery.data?.data?.policies;
+    if (Array.isArray(apiPolicies) && apiPolicies.length > 0) {
+      return apiPolicies;
+    }
+    return session.policies;
+  }, [policiesQuery.data, session.policies]);
+
+  const profilesByPolicy = useMemo(() => {
+    const profiles = paymentProfilesQuery.data?.data?.paymentProfiles ?? [];
+    const map = new Map<string, CustomerPaymentProfile>();
+    for (const profile of profiles) {
+      map.set(profile.policyId, profile);
+    }
+    return map;
+  }, [paymentProfilesQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: async ({ policyId, form }: { policyId: string; form: PaymentFormState }) => {
+      const payload: Record<string, unknown> = {
+        paymentMethod: form.paymentMethod.trim() || undefined,
+        accountName: form.accountName.trim() || undefined,
+        accountIdentifier: form.accountIdentifier.trim() || undefined,
+        autopayEnabled: form.autopayEnabled,
+        notes: form.notes.trim() || undefined,
+      };
+      return fetchCustomerJson<{ data: CustomerPaymentProfile }>(
+        `/api/customer/policies/${policyId}/payment-profile`,
+        {
+          method: "PUT",
+          body: JSON.stringify(payload),
+        },
+      );
+    },
+    onSuccess: () => {
+      toast({
+        title: "Preferences saved",
+        description: "We updated your billing instructions.",
+      });
+      void queryClient.invalidateQueries(["/api/customer/payment-profiles"]);
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : "We couldn’t save those details.";
+      toast({ title: "Save failed", description: message, variant: "destructive" });
+    },
+  });
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-slate-900">Payment Preferences</h1>
+        <p className="text-slate-600 mt-2">
+          Manage the details our billing team will use when collecting your monthly coverage payments.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        {policies.length === 0 ? (
+          <Card>
+            <CardContent className="py-8 text-sm text-slate-500">
+              We don’t see any policies linked to your portal yet. Once your coverage is active you’ll be able to manage your
+              billing preferences here.
+            </CardContent>
+          </Card>
+        ) : (
+          policies.map((policy) => (
+            <PaymentCard
+              key={policy.id}
+              policy={policy}
+              profile={profilesByPolicy.get(policy.id)}
+              saving={mutation.isLoading}
+              onSave={(form) => mutation.mutate({ policyId: policy.id, form })}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/portal/policy-request.tsx
+++ b/client/src/pages/portal/policy-request.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { useMutation } from "@tanstack/react-query";
+import { fetchCustomerJson, type CustomerSessionSnapshot } from "@/lib/customer-auth";
+import { useToast } from "@/hooks/use-toast";
+
+type Props = {
+  session: CustomerSessionSnapshot;
+};
+
+type PolicyRequestForm = {
+  year: string;
+  make: string;
+  model: string;
+  trim: string;
+  vin: string;
+  odometer: string;
+  phone: string;
+  message: string;
+};
+
+const initialForm: PolicyRequestForm = {
+  year: "",
+  make: "",
+  model: "",
+  trim: "",
+  vin: "",
+  odometer: "",
+  phone: "",
+  message: "",
+};
+
+function normalizeNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed.replace(/,/g, ""));
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+export default function CustomerPortalPolicyRequest({ session }: Props) {
+  const { toast } = useToast();
+  const [form, setForm] = useState<PolicyRequestForm>(initialForm);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const payload: Record<string, unknown> = {
+        message: form.message.trim(),
+      };
+
+      if (form.phone.trim()) {
+        payload.phone = form.phone.trim();
+      }
+
+      const vehicle: Record<string, unknown> = {};
+      if (form.year.trim()) {
+        const yearNumber = Number(form.year.trim());
+        if (!Number.isNaN(yearNumber)) {
+          vehicle.year = yearNumber;
+        }
+      }
+      if (form.make.trim()) vehicle.make = form.make.trim();
+      if (form.model.trim()) vehicle.model = form.model.trim();
+      if (form.trim.trim()) vehicle.trim = form.trim.trim();
+      if (form.vin.trim()) vehicle.vin = form.vin.trim();
+      const odometer = normalizeNumber(form.odometer);
+      if (odometer !== undefined) vehicle.odometer = odometer;
+
+      if (Object.keys(vehicle).length > 0) {
+        payload.vehicle = vehicle;
+      }
+
+      return fetchCustomerJson("/api/customer/policies/request", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    },
+    onSuccess: () => {
+      toast({
+        title: "Request sent",
+        description: "A coverage specialist will reach out with plan options shortly.",
+      });
+      setForm(initialForm);
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : "We couldn’t submit your request.";
+      toast({ title: "Submission failed", description: message, variant: "destructive" });
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!form.message.trim()) {
+      toast({ title: "Tell us what you need", description: "A short note helps our team prepare options." });
+      return;
+    }
+    mutation.mutate();
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-slate-900">Add Coverage</h1>
+        <p className="text-slate-600 mt-2">
+          Already protected with us? Share the details on the next vehicle you’d like to cover and our concierge team will
+          craft options to match.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Request a Quote</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="year">Vehicle year</Label>
+                <Input
+                  id="year"
+                  inputMode="numeric"
+                  placeholder="2021"
+                  value={form.year}
+                  onChange={(event) => setForm((current) => ({ ...current, year: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="odometer">Current odometer</Label>
+                <Input
+                  id="odometer"
+                  inputMode="numeric"
+                  placeholder="50,000"
+                  value={form.odometer}
+                  onChange={(event) => setForm((current) => ({ ...current, odometer: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="grid md:grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="make">Make</Label>
+                <Input
+                  id="make"
+                  placeholder="Toyota"
+                  value={form.make}
+                  onChange={(event) => setForm((current) => ({ ...current, make: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="model">Model</Label>
+                <Input
+                  id="model"
+                  placeholder="Highlander"
+                  value={form.model}
+                  onChange={(event) => setForm((current) => ({ ...current, model: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="trim">Trim</Label>
+                <Input
+                  id="trim"
+                  placeholder="Limited"
+                  value={form.trim}
+                  onChange={(event) => setForm((current) => ({ ...current, trim: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vin">VIN (optional)</Label>
+              <Input
+                id="vin"
+                placeholder="1FTFW1ET1EFA00000"
+                value={form.vin}
+                onChange={(event) => setForm((current) => ({ ...current, vin: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="phone">Preferred phone</Label>
+              <Input
+                id="phone"
+                placeholder="We’ll confirm details by phone or email"
+                value={form.phone}
+                onChange={(event) => setForm((current) => ({ ...current, phone: event.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="message">How can we help?</Label>
+              <Textarea
+                id="message"
+                rows={6}
+                placeholder="Let us know how you use the vehicle, any coverage preferences, or timing requirements."
+                value={form.message}
+                onChange={(event) => setForm((current) => ({ ...current, message: event.target.value }))}
+              />
+            </div>
+            <Button type="submit" disabled={mutation.isLoading}>
+              {mutation.isLoading ? "Sending..." : "Submit request"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add database tables and storage helpers for customer accounts, policy links, and payment profiles
- expose customer authentication, policy, claim, payment, and request endpoints
- build a customer portal UI with login/register, overview, claims, payments, and add-coverage pages and surface the portal in site navigation

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cb2abaf24c8330b5dd0f470fb3e6cc