### PR TITLE
Add unique index for customer policies

### DIFF
--- a/migrations/0001_fix_customer_policies_unique_constraint.sql
+++ b/migrations/0001_fix_customer_policies_unique_constraint.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+WITH duplicates AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY customer_id, policy_id
+      ORDER BY created_at NULLS LAST, id
+    ) AS row_number
+  FROM customer_policies
+)
+DELETE FROM customer_policies
+WHERE id IN (
+  SELECT id
+  FROM duplicates
+  WHERE row_number > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS customer_policies_unique_idx
+  ON customer_policies (customer_id, policy_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration that removes duplicate customer/policy links
- create the missing unique index so conflict handling works when linking customers to policies

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb2fed9d0c8330ba1c8ffeecc0cd7d