### PR TITLE
Add migration to cast quote plan to enum

### DIFF
--- a/migrations/0002_add_plan_type_enum.sql
+++ b/migrations/0002_add_plan_type_enum.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+    CREATE TYPE "plan_type" AS ENUM ('basic', 'bronze', 'silver', 'gold');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "quotes"
+  ALTER COLUMN "plan" TYPE "plan_type"
+  USING "plan"::"plan_type";


### PR DESCRIPTION
## Summary
- add migration to ensure the quotes.plan column is converted to the plan_type enum using an explicit cast

## Testing
- not run (database credentials not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb31c1bc548330a0a96e3fe3a6a163