### PR TITLE
feat: add document request workflow to portal

### DIFF
--- a/client/src/components/admin-policy-document-requests.tsx
+++ b/client/src/components/admin-policy-document-requests.tsx
@@ -1,0 +1,402 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  DOCUMENT_REQUEST_STATUS_COPY,
+  DOCUMENT_REQUEST_TYPE_COPY,
+  type CustomerDocumentRequestRecord,
+  formatFileSize,
+} from "@/lib/document-requests";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { fetchWithAuth, getAuthHeaders } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+import { Calendar, CheckCircle2, UploadCloud, FileDown, Clock3 } from "lucide-react";
+
+type Props = {
+  policyId: string;
+  customers: { id: string; email: string; displayName?: string | null }[];
+};
+
+type AdminDocumentRequestsResponse = {
+  data?: { requests?: CustomerDocumentRequestRecord[] };
+};
+
+type AdminDocumentUploadResponse = {
+  data?: {
+    dataUrl?: string;
+    fileName?: string;
+    fileType?: string | null;
+  };
+};
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return "—";
+  return dateFormatter.format(parsed);
+}
+
+function downloadDataUrl(dataUrl: string, filename: string) {
+  const link = document.createElement("a");
+  link.href = dataUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}
+
+export default function PolicyDocumentRequests({ policyId, customers }: Props) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [customerId, setCustomerId] = useState(customers[0]?.id ?? "");
+  const [type, setType] = useState<keyof typeof DOCUMENT_REQUEST_TYPE_COPY>("vin_photo");
+  const [title, setTitle] = useState("VIN photo for verification");
+  const [instructions, setInstructions] = useState("");
+  const [dueDate, setDueDate] = useState<string>("");
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const hasCustomers = customers.length > 0;
+
+  const { data, isLoading } = useQuery<AdminDocumentRequestsResponse>({
+    queryKey: ["/api/admin/policies", policyId, "document-requests"],
+    queryFn: async () => {
+      const res = await fetchWithAuth(`/api/admin/policies/${policyId}/document-requests`, {
+        headers: getAuthHeaders(),
+      });
+      if (!res.ok) {
+        throw new Error("Failed to load document requests");
+      }
+      return res.json();
+    },
+  });
+
+  const requests = useMemo(() => data?.data?.requests ?? [], [data]);
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const payload = {
+        customerId,
+        type,
+        title,
+        instructions: instructions.trim() || undefined,
+        dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
+      };
+      const res = await fetchWithAuth(`/api/admin/policies/${policyId}/document-requests`, {
+        method: "POST",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        const message = typeof (json as { message?: unknown }).message === "string" ? (json as { message: string }).message : "Unable to create request";
+        throw new Error(message);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/policies", policyId, "document-requests"] });
+      toast({
+        title: "Request sent",
+        description: "The customer will now see this document request in their portal.",
+      });
+      setInstructions("");
+      setDueDate("");
+    },
+    onError: (error: Error) => {
+      toast({ title: "Unable to create request", description: error.message, variant: "destructive" });
+    },
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: async ({ requestId, status }: { requestId: string; status: string }) => {
+      const res = await fetchWithAuth(`/api/admin/document-requests/${requestId}/status`, {
+        method: "POST",
+        headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        const message = typeof (json as { message?: unknown }).message === "string" ? (json as { message: string }).message : "Unable to update status";
+        throw new Error(message);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/policies", policyId, "document-requests"] });
+      toast({ title: "Status updated" });
+    },
+    onError: (error: Error) => {
+      toast({ title: "Update failed", description: error.message, variant: "destructive" });
+    },
+  });
+
+  const handleDownload = async (uploadId: string, fileName: string) => {
+    try {
+      setDownloadingId(uploadId);
+      const res = await fetchWithAuth(`/api/admin/document-uploads/${uploadId}`, {
+        headers: getAuthHeaders(),
+      });
+      if (!res.ok) {
+        throw new Error("Unable to retrieve file");
+      }
+      const json = (await res.json()) as AdminDocumentUploadResponse;
+      const dataUrl = json?.data?.dataUrl;
+      if (typeof dataUrl === "string") {
+        downloadDataUrl(dataUrl, fileName);
+      } else {
+        throw new Error("Missing file data");
+      }
+    } catch (error) {
+      toast({
+        title: "Download failed",
+        description: error instanceof Error ? error.message : "We couldn’t fetch that file.",
+        variant: "destructive",
+      });
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-slate-200 bg-white/70 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base font-semibold text-slate-900">Request new documentation</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!hasCustomers ? (
+            <div className="rounded-lg border border-slate-200 bg-slate-50/80 px-4 py-5 text-sm text-slate-500">
+              Link a customer portal user to this policy to send document requests.
+            </div>
+          ) : (
+            <>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="admin-document-customer">Customer</Label>
+              <Select value={customerId} onValueChange={setCustomerId}>
+                <SelectTrigger id="admin-document-customer">
+                  <SelectValue placeholder="Select customer" />
+                </SelectTrigger>
+                <SelectContent>
+                  {customers.map((customer) => (
+                    <SelectItem key={customer.id} value={customer.id}>
+                      {customer.displayName?.trim() || customer.email}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="admin-document-type">Document type</Label>
+              <Select value={type} onValueChange={(value) => setType(value as typeof type)}>
+                <SelectTrigger id="admin-document-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(DOCUMENT_REQUEST_TYPE_COPY) as Array<keyof typeof DOCUMENT_REQUEST_TYPE_COPY>).map((key) => (
+                    <SelectItem key={key} value={key}>
+                      {DOCUMENT_REQUEST_TYPE_COPY[key].label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="admin-document-due">Due date (optional)</Label>
+              <div className="relative">
+                <Calendar className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                <Input
+                  id="admin-document-due"
+                  type="date"
+                  value={dueDate}
+                  onChange={(event) => setDueDate(event.target.value)}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="admin-document-title">Title</Label>
+              <Input
+                id="admin-document-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Example: VIN verification photo"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="admin-document-instructions">Instructions</Label>
+              <Textarea
+                id="admin-document-instructions"
+                value={instructions}
+                onChange={(event) => setInstructions(event.target.value)}
+                placeholder={DOCUMENT_REQUEST_TYPE_COPY[type].hint}
+                className="min-h-[88px]"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={() => createMutation.mutate()} disabled={!customerId || !title.trim() || createMutation.isPending}>
+              {createMutation.isPending ? "Sending…" : "Create request"}
+            </Button>
+          </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Requests on file</h3>
+          <p className="text-sm text-slate-500">
+            Track what’s been asked for, see customer uploads, and close out tasks once everything looks good.
+          </p>
+        </div>
+        {isLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-44 rounded-xl" />
+            <Skeleton className="h-44 rounded-xl" />
+          </div>
+        ) : requests.length === 0 ? (
+          <div className="flex items-center gap-3 rounded-xl border border-dashed border-slate-200 bg-slate-50/70 px-4 py-6 text-sm text-slate-500">
+            <UploadCloud className="h-5 w-5 text-slate-300" />
+            No document requests yet for this policy.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {requests.map((request) => {
+              const typeInfo = DOCUMENT_REQUEST_TYPE_COPY[request.type];
+              const statusInfo = DOCUMENT_REQUEST_STATUS_COPY[request.status];
+              const toneClass =
+                statusInfo.tone === "success"
+                  ? "bg-emerald-100 text-emerald-900 border border-emerald-200"
+                  : statusInfo.tone === "notice"
+                    ? "bg-amber-100 text-amber-900 border border-amber-200"
+                    : statusInfo.tone === "pending"
+                      ? "bg-sky-100 text-sky-900 border border-sky-200"
+                      : "bg-slate-100 text-slate-600 border border-slate-200";
+
+              return (
+                <Card key={request.id} className="overflow-hidden border-slate-200">
+                  <CardHeader className="space-y-4 bg-gradient-to-br from-white via-slate-50 to-white">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="outline" className="border-primary/40 bg-primary/5 text-primary">
+                        {typeInfo.label}
+                      </Badge>
+                      <span className={cn("inline-flex items-center rounded-full px-3 py-1 text-xs font-medium", toneClass)}>
+                        {statusInfo.label}
+                      </span>
+                      {request.dueDate ? (
+                        <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-900">
+                          <Clock3 className="h-3.5 w-3.5" /> Due {formatDate(request.dueDate)}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg font-semibold text-slate-900">{request.title}</CardTitle>
+                      <p className="text-sm text-slate-500">
+                        {request.customer?.displayName?.trim() || request.customer?.email} • Policy {request.policyId}
+                      </p>
+                      <p className="text-xs text-slate-500">{statusInfo.description}</p>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4 text-sm text-slate-600">
+                    <div className="rounded-lg border border-dashed border-slate-200 bg-white/70 p-4">
+                      <p className="font-medium text-slate-700">Instructions for the customer</p>
+                      <p className="mt-2 text-sm text-slate-600">
+                        {request.instructions?.trim() || typeInfo.hint}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={statusMutation.isPending}
+                        onClick={() => statusMutation.mutate({ requestId: request.id, status: "submitted" })}
+                      >
+                        Mark as received
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={statusMutation.isPending}
+                        onClick={() => statusMutation.mutate({ requestId: request.id, status: "completed" })}
+                      >
+                        Close out request
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={statusMutation.isPending}
+                        onClick={() => statusMutation.mutate({ requestId: request.id, status: "pending" })}
+                      >
+                        Re-open
+                      </Button>
+                    </div>
+                    {request.uploads.length > 0 ? (
+                      <div className="space-y-2">
+                        <p className="text-sm font-semibold text-slate-700">Customer uploads</p>
+                        <div className="space-y-2">
+                          {request.uploads.map((upload) => (
+                            <div
+                              key={upload.id}
+                              className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm"
+                            >
+                              <div>
+                                <p className="font-medium text-slate-800">{upload.fileName}</p>
+                                <p className="text-xs text-slate-500">
+                                  {formatFileSize(upload.fileSize)} • Uploaded {formatDate(upload.createdAt)}
+                                </p>
+                              </div>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                className="border-slate-200"
+                                onClick={() => handleDownload(upload.id, upload.fileName)}
+                                disabled={downloadingId === upload.id}
+                              >
+                                {downloadingId === upload.id ? "Preparing…" : "Download"}
+                                <FileDown className="ml-2 h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="rounded-lg border border-slate-200 bg-slate-50/60 px-4 py-3 text-xs text-slate-500">
+                        No files uploaded yet.
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/lib/document-requests.ts
+++ b/client/src/lib/document-requests.ts
@@ -1,0 +1,132 @@
+export type DocumentRequestType =
+  | 'vin_photo'
+  | 'odometer_photo'
+  | 'diagnosis_report'
+  | 'repair_invoice'
+  | 'other';
+
+export type DocumentRequestStatus = 'pending' | 'submitted' | 'completed' | 'cancelled';
+
+export type DocumentUploadMeta = {
+  id: string;
+  fileName: string;
+  fileType: string | null;
+  fileSize: number | null;
+  createdAt: string | null;
+};
+
+export type DocumentPolicySummary = {
+  id: string;
+  package: string | null;
+  policyStartDate: string | null;
+  expirationDate: string | null;
+  lead: {
+    firstName: string | null;
+    lastName: string | null;
+  } | null;
+  vehicle: {
+    year: number | null;
+    make: string | null;
+    model: string | null;
+    vin: string | null;
+  } | null;
+} | null;
+
+export type CustomerDocumentRequestRecord = {
+  id: string;
+  policyId: string;
+  customerId?: string;
+  customer?: {
+    id: string;
+    email: string;
+    displayName: string | null;
+  } | null;
+  type: DocumentRequestType;
+  title: string;
+  instructions: string | null;
+  status: DocumentRequestStatus;
+  dueDate: string | null;
+  requestedBy: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  policy: DocumentPolicySummary;
+  uploads: DocumentUploadMeta[];
+};
+
+export const DOCUMENT_REQUEST_TYPE_COPY: Record<
+  DocumentRequestType,
+  { label: string; hint: string }
+> = {
+  vin_photo: {
+    label: 'VIN Photo',
+    hint: 'Upload a clear photo of the VIN plate or door jamb sticker.',
+  },
+  odometer_photo: {
+    label: 'Odometer Reading',
+    hint: 'Capture the current mileage in your dashboard display.',
+  },
+  diagnosis_report: {
+    label: 'Diagnosis Report',
+    hint: 'Share the technician or dealership findings for your issue.',
+  },
+  repair_invoice: {
+    label: 'Repair Invoice',
+    hint: 'Send the itemized invoice so we can process reimbursement quickly.',
+  },
+  other: {
+    label: 'Supporting Document',
+    hint: 'Provide any additional paperwork our team asked for.',
+  },
+};
+
+export const DOCUMENT_REQUEST_STATUS_COPY: Record<
+  DocumentRequestStatus,
+  { label: string; description: string; tone: 'pending' | 'notice' | 'success' | 'muted' }
+> = {
+  pending: {
+    label: 'Awaiting Upload',
+    description: 'We’re waiting on files from you to finish this step.',
+    tone: 'notice',
+  },
+  submitted: {
+    label: 'Received',
+    description: 'Thanks! Our team is reviewing what you sent.',
+    tone: 'pending',
+  },
+  completed: {
+    label: 'Completed',
+    description: 'All set. We have everything we need here.',
+    tone: 'success',
+  },
+  cancelled: {
+    label: 'No Longer Needed',
+    description: 'This request was cancelled by our team.',
+    tone: 'muted',
+  },
+};
+
+export const formatFileSize = (bytes: number | null | undefined): string => {
+  if (!bytes || bytes <= 0) {
+    return '—';
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${kb.toFixed(kb >= 100 ? 0 : 1)} KB`;
+  }
+  const mb = kb / 1024;
+  return `${mb.toFixed(mb >= 100 ? 0 : 1)} MB`;
+};
+
+export const summarizeVehicle = (policy: DocumentPolicySummary): string => {
+  if (!policy?.vehicle) {
+    return 'Vehicle on file';
+  }
+  const { year, make, model } = policy.vehicle;
+  return [year ?? undefined, make || undefined, model || undefined]
+    .filter((part) => part != null && `${part}`.trim().length > 0)
+    .join(' ')
+    .trim() || 'Vehicle on file';
+};

--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -19,6 +19,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import AdminNav from "@/components/admin-nav";
 import { fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
+import PolicyDocumentRequests from "@/components/admin-policy-document-requests";
 import { ArrowLeft } from "lucide-react";
 
 const CUSTOM_TEMPLATE_ID = "custom";
@@ -847,6 +848,8 @@ export default function AdminPolicyDetail() {
             </ul>
           </CardContent>
         </Card>
+
+        <PolicyDocumentRequests policyId={policy.id} customers={policy.customers ?? []} />
       </div>
       <Dialog
         open={isEmailDialogOpen}

--- a/client/src/pages/portal/documents.tsx
+++ b/client/src/pages/portal/documents.tsx
@@ -1,0 +1,458 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  DOCUMENT_REQUEST_STATUS_COPY,
+  DOCUMENT_REQUEST_TYPE_COPY,
+  type CustomerDocumentRequestRecord,
+  formatFileSize,
+  summarizeVehicle,
+} from "@/lib/document-requests";
+import type { CustomerSessionSnapshot } from "@/lib/customer-auth";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock3,
+  FileDown,
+  Inbox,
+  Paperclip,
+  UploadCloud,
+} from "lucide-react";
+
+type Props = {
+  session: CustomerSessionSnapshot;
+};
+
+type UploadPayload = {
+  requestId: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+  data: string;
+};
+
+const STATUS_TONE_CLASSES: Record<string, string> = {
+  notice: "bg-amber-100 text-amber-900 border border-amber-200",
+  pending: "bg-sky-100 text-sky-900 border border-sky-200",
+  success: "bg-emerald-100 text-emerald-900 border border-emerald-200",
+  muted: "bg-slate-100 text-slate-600 border border-slate-200",
+};
+
+const formatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return "—";
+  return formatter.format(parsed);
+}
+
+async function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Unable to read file"));
+      }
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("Unable to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function buildDownloadLink(dataUrl: string, filename: string) {
+  const link = document.createElement("a");
+  link.href = dataUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}
+
+type DocumentRequestCardProps = {
+  request: CustomerDocumentRequestRecord;
+};
+
+function DocumentRequestCard({ request }: DocumentRequestCardProps) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [fileState, setFileState] = useState<{ file: File; dataUrl: string } | null>(null);
+  const [isReading, setIsReading] = useState(false);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const uploadMutation = useMutation({
+    mutationFn: async (payload: UploadPayload) => {
+      const res = await fetch(`/api/customer/document-requests/${payload.requestId}/upload`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          fileName: payload.fileName,
+          fileType: payload.fileType,
+          fileSize: payload.fileSize,
+          data: payload.data,
+        }),
+      });
+
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        const message = typeof (json as { message?: unknown }).message === "string" ? (json as { message: string }).message : "Unable to upload file";
+        throw new Error(message);
+      }
+
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/customer/document-requests"] });
+      setFileState(null);
+      toast({
+        title: "Upload received",
+        description: "Thanks! Our document team has your file and will review it shortly.",
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Upload failed",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setFileState(null);
+      return;
+    }
+    setIsReading(true);
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      setFileState({ file, dataUrl });
+    } catch (error) {
+      console.error(error);
+      setFileState(null);
+      toast({
+        title: "Unable to read file",
+        description: "Please try selecting a different file.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsReading(false);
+    }
+  };
+
+  const handleUpload = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!fileState || uploadMutation.isPending) return;
+
+    uploadMutation.mutate({
+      requestId: request.id,
+      fileName: fileState.file.name,
+      fileType: fileState.file.type,
+      fileSize: fileState.file.size,
+      data: fileState.dataUrl,
+    });
+  };
+
+  const handleDownload = async (uploadId: string, fileName: string) => {
+    try {
+      setDownloadingId(uploadId);
+      const res = await fetch(`/api/customer/document-uploads/${uploadId}`, {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        throw new Error("Unable to download file");
+      }
+      const json = (await res.json()) as { data?: { dataUrl?: string } };
+      const dataUrl = json?.data?.dataUrl;
+      if (typeof dataUrl === "string" && dataUrl.startsWith("data:")) {
+        buildDownloadLink(dataUrl, fileName);
+      } else {
+        throw new Error("The file could not be downloaded");
+      }
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: "Download failed",
+        description: "We couldn’t retrieve that file. Please try again in a moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  const typeInfo = DOCUMENT_REQUEST_TYPE_COPY[request.type];
+  const statusInfo = DOCUMENT_REQUEST_STATUS_COPY[request.status];
+  const statusClasses = STATUS_TONE_CLASSES[statusInfo.tone] ?? STATUS_TONE_CLASSES.muted;
+  const hasUploads = request.uploads.length > 0;
+  const uploadDisabled = request.status === "completed" || request.status === "cancelled";
+
+  return (
+    <Card className="overflow-hidden border-slate-200 shadow-sm">
+      <CardHeader className="space-y-4 border-b border-slate-100 bg-gradient-to-br from-white via-slate-50 to-white">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline" className="border-primary/40 bg-primary/5 text-primary">
+            {typeInfo.label}
+          </Badge>
+          <span className={cn("inline-flex items-center rounded-full px-3 py-1 text-xs font-medium", statusClasses)}>
+            {statusInfo.label}
+          </span>
+          {request.dueDate ? (
+            <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-900">
+              <Clock3 className="h-3.5 w-3.5" /> Due {formatDate(request.dueDate)}
+            </span>
+          ) : null}
+        </div>
+        <div className="space-y-1">
+          <CardTitle className="text-xl font-semibold text-slate-900">{request.title}</CardTitle>
+          <CardDescription className="text-sm text-slate-500">
+            {`Policy ${request.policy?.id ?? request.policyId}`} • {summarizeVehicle(request.policy)}
+          </CardDescription>
+          <p className="text-sm text-slate-500">{statusInfo.description}</p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-600">
+          <p className="font-medium text-slate-700">What to upload</p>
+          <p className="mt-2 leading-relaxed">{request.instructions || typeInfo.hint}</p>
+        </div>
+        <form onSubmit={handleUpload} className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-[1fr_auto] md:items-center">
+            <label className="flex h-full flex-col rounded-lg border border-slate-200 bg-white/60 p-4 text-sm text-slate-600 shadow-sm transition hover:border-slate-300">
+              <span className="flex items-center gap-2 text-slate-700">
+                <UploadCloud className="h-4 w-4 text-primary" />
+                Choose a file
+              </span>
+              <span className="mt-1 text-xs text-slate-500">JPG, PNG, HEIC, or PDF up to 5MB.</span>
+              <Input type="file" className="mt-3 cursor-pointer border-0 px-0 text-sm" accept="image/*,.pdf" onChange={handleFileChange} disabled={uploadDisabled || uploadMutation.isPending || isReading} />
+            </label>
+            <Button type="submit" className="justify-self-end" disabled={!fileState || uploadDisabled || uploadMutation.isPending || isReading}>
+              {uploadMutation.isPending ? "Uploading…" : "Send to BH"}
+            </Button>
+          </div>
+          {fileState ? (
+            <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-600">
+              <Paperclip className="h-4 w-4 text-slate-400" />
+              <div className="flex-1 truncate">
+                <p className="truncate font-medium text-slate-700">{fileState.file.name}</p>
+                <p className="text-xs text-slate-500">{formatFileSize(fileState.file.size)} • {fileState.file.type || "Unknown type"}</p>
+              </div>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setFileState(null)}>
+                Clear
+              </Button>
+            </div>
+          ) : null}
+        </form>
+        {hasUploads ? (
+          <div className="space-y-3">
+            <h4 className="text-sm font-semibold text-slate-700">What you’ve already sent</h4>
+            <div className="space-y-2">
+              {request.uploads.map((upload) => (
+                <div
+                  key={upload.id}
+                  className="flex items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600"
+                >
+                  <div className="flex flex-col">
+                    <span className="font-medium text-slate-700">{upload.fileName}</span>
+                    <span className="text-xs text-slate-500">
+                      {formatFileSize(upload.fileSize)} • Uploaded {formatDate(upload.createdAt)}
+                    </span>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleDownload(upload.id, upload.fileName)}
+                    disabled={downloadingId === upload.id}
+                    className="border-slate-200"
+                  >
+                    {downloadingId === upload.id ? "Preparing…" : "Download"}
+                    <FileDown className="ml-2 h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function CustomerPortalDocuments({ session }: Props) {
+  const { data, isLoading } = useQuery<{ data?: { requests?: CustomerDocumentRequestRecord[] } }>([
+    "/api/customer/document-requests",
+  ]);
+  const requests = useMemo(() => data?.data?.requests ?? [], [data]);
+  const openRequests = useMemo(
+    () => requests.filter((request) => request.status !== "completed" && request.status !== "cancelled"),
+    [requests],
+  );
+  const completedRequests = useMemo(
+    () => requests.filter((request) => request.status === "completed"),
+    [requests],
+  );
+  const recentUploads = useMemo(() => {
+    const uploads = requests.flatMap((request) =>
+      request.uploads.map((upload) => ({
+        ...upload,
+        request,
+      })),
+    );
+    return uploads.sort((a, b) => {
+      const aTime = a.createdAt ? new Date(a.createdAt).valueOf() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).valueOf() : 0;
+      return bTime - aTime;
+    });
+  }, [requests]);
+
+  const nextDueDate = useMemo(() => {
+    let earliest: string | null = null;
+    for (const request of openRequests) {
+      if (!request.dueDate) continue;
+      if (!earliest || new Date(request.dueDate).valueOf() < new Date(earliest).valueOf()) {
+        earliest = request.dueDate;
+      }
+    }
+    return earliest;
+  }, [openRequests]);
+
+  const totalPolicies = session.policies.length;
+
+  return (
+    <div className="space-y-10">
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="grid gap-6 bg-gradient-to-br from-primary/10 via-white to-white px-6 py-8 md:grid-cols-3">
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-slate-900">Document center</h2>
+            <p className="text-sm text-slate-600">
+              Upload photos and paperwork our claims team needs. We’ll show the latest requests and confirmations below.
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white/80 p-4 text-sm text-slate-600 shadow-sm">
+            <div className="flex items-center gap-3">
+              <AlertCircle className="h-5 w-5 text-amber-500" />
+              <div>
+                <p className="text-xs uppercase tracking-[0.22em] text-amber-500">Outstanding</p>
+                <p className="text-lg font-semibold text-slate-900">{openRequests.length}</p>
+              </div>
+            </div>
+            <p className="mt-2 text-xs text-slate-500">
+              {openRequests.length === 0
+                ? "No open tasks right now."
+                : nextDueDate
+                  ? `Next due ${formatDate(nextDueDate)}.`
+                  : "Submit whenever it’s convenient—no deadlines set."}
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white/80 p-4 text-sm text-slate-600 shadow-sm">
+            <div className="flex items-center gap-3">
+              <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+              <div>
+                <p className="text-xs uppercase tracking-[0.22em] text-emerald-500">Completed</p>
+                <p className="text-lg font-semibold text-slate-900">{completedRequests.length}</p>
+              </div>
+            </div>
+            <p className="mt-2 text-xs text-slate-500">
+              {completedRequests.length === 0
+                ? "We’ll mark items complete once reviewed."
+                : "Everything listed here has been cleared by our team."}
+            </p>
+          </div>
+        </div>
+        <div className="border-t border-slate-200 bg-white px-6 py-5 text-sm text-slate-600">
+          <p>
+            Covered vehicles on file: <span className="font-medium text-slate-900">{totalPolicies}</span>. Need help? Email{' '}
+            <a className="font-medium text-primary" href="mailto:support@bhautoprotect.com">
+              support@bhautoprotect.com
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900">Open requests</h3>
+            <p className="text-sm text-slate-500">
+              We’ll keep this list updated as soon as someone from the BH Auto Protect team asks for new documentation.
+            </p>
+          </div>
+        </div>
+        {isLoading ? (
+          <div className="grid gap-5 md:grid-cols-2">
+            <Skeleton className="h-64 rounded-2xl" />
+            <Skeleton className="h-64 rounded-2xl" />
+          </div>
+        ) : openRequests.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-200 bg-white p-10 text-center text-slate-500">
+            <Inbox className="h-10 w-10 text-slate-300" />
+            <div className="space-y-1">
+              <p className="font-medium text-slate-700">No outstanding uploads</p>
+              <p className="text-sm text-slate-500">
+                When we need something from you—like a VIN photo or diagnosis report—it’ll appear here instantly.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {openRequests.map((request) => (
+              <DocumentRequestCard key={request.id} request={request} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {recentUploads.length > 0 ? (
+        <section className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Paperclip className="h-5 w-5 text-slate-400" />
+            <h3 className="text-lg font-semibold text-slate-900">Recent uploads</h3>
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div className="max-h-[360px] overflow-y-auto">
+              <table className="min-w-full divide-y divide-slate-200 text-sm">
+                <thead className="bg-slate-50 text-left text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">File</th>
+                    <th className="px-4 py-3 font-medium">Request</th>
+                    <th className="px-4 py-3 font-medium">Uploaded</th>
+                    <th className="px-4 py-3 font-medium text-right">Size</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 text-slate-600">
+                  {recentUploads.slice(0, 6).map((upload) => (
+                    <tr key={upload.id}>
+                      <td className="px-4 py-3 font-medium text-slate-700">{upload.fileName}</td>
+                      <td className="px-4 py-3">
+                        <div className="text-sm font-medium text-slate-700">{upload.request.title}</div>
+                        <div className="text-xs text-slate-500">{DOCUMENT_REQUEST_TYPE_COPY[upload.request.type].label}</div>
+                      </td>
+                      <td className="px-4 py-3">{formatDate(upload.createdAt)}</td>
+                      <td className="px-4 py-3 text-right">{formatFileSize(upload.fileSize)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/pages/portal/index.tsx
+++ b/client/src/pages/portal/index.tsx
@@ -6,6 +6,7 @@ import CustomerPortalOverview from "./overview";
 import CustomerPortalClaims from "./claims";
 import CustomerPortalPayments from "./payments";
 import CustomerPortalPolicyRequest from "./policy-request";
+import CustomerPortalDocuments from "./documents";
 import {
   checkCustomerSession,
   logoutCustomer,
@@ -16,6 +17,7 @@ const NAV_LINKS = [
   { href: "/portal", label: "Overview" },
   { href: "/portal/claims", label: "Claims" },
   { href: "/portal/payments", label: "Payments" },
+  { href: "/portal/documents", label: "Documents" },
   { href: "/portal/policies/new", label: "Add Coverage" },
 ];
 
@@ -85,33 +87,42 @@ export default function CustomerPortal() {
 
   return (
     <div className="min-h-screen bg-slate-100">
-      <header className="bg-slate-900 text-white shadow">
-        <div className="max-w-6xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">BH Auto Protect</p>
-            <h1 className="text-2xl font-semibold">Customer Portal</h1>
-          </div>
-          <div className="flex items-center gap-4">
-            <div className="text-right text-sm text-slate-300">
-              <p className="font-medium text-white">{displayName}</p>
-              {session.customer.displayName && session.customer.displayName !== session.customer.email ? (
-                <p>{session.customer.email}</p>
-              ) : null}
+      <header className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-slate-950" />
+        <div className="absolute inset-x-0 top-0 h-full bg-gradient-to-br from-primary/30 via-transparent to-slate-900 opacity-80" />
+        <div className="relative">
+          <div className="max-w-6xl mx-auto px-4 py-10">
+            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-3 text-white">
+                <p className="text-xs uppercase tracking-[0.32em] text-white/70">BH Auto Protect</p>
+                <h1 className="text-3xl font-semibold tracking-tight">Welcome back, {displayName || "there"}</h1>
+                <p className="max-w-xl text-sm text-white/70">
+                  Keep your coverage, claims, and paperwork organized in one place. We’ll highlight anything that needs your attention first.
+                </p>
+              </div>
+              <div className="flex items-center gap-4 text-sm text-white/80">
+                <div className="text-right">
+                  <p className="font-medium text-white">{displayName}</p>
+                  {session.customer.displayName && session.customer.displayName !== session.customer.email ? (
+                    <p className="text-white/70">{session.customer.email}</p>
+                  ) : null}
+                </div>
+                <Button variant="outline" onClick={handleLogout} className="border-white/40 bg-white/5 hover:bg-white/10">
+                  Sign out
+                </Button>
+              </div>
             </div>
-            <Button variant="outline" onClick={handleLogout} className="bg-white/10 hover:bg-white/20">
-              Sign out
-            </Button>
           </div>
         </div>
-        <nav className="bg-slate-800">
+        <nav className="relative border-t border-white/10 bg-slate-900/60 backdrop-blur">
           <div className="max-w-6xl mx-auto px-4 py-3 flex flex-wrap gap-2">
             {NAV_LINKS.map((link) => (
               <Link key={link.href} href={link.href} className="group">
                 <span
-                  className={`inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  className={`inline-flex items-center rounded-full px-3.5 py-2 text-sm font-medium transition-all ${
                     isActiveLink(link.href)
                       ? "bg-white text-slate-900 shadow"
-                      : "text-slate-200 hover:text-white hover:bg-slate-700"
+                      : "text-white/80 hover:text-white hover:bg-white/10"
                   }`}
                 >
                   {link.label}
@@ -132,6 +143,9 @@ export default function CustomerPortal() {
           </Route>
           <Route path="/portal/payments">
             <CustomerPortalPayments session={session} />
+          </Route>
+          <Route path="/portal/documents">
+            <CustomerPortalDocuments session={session} />
           </Route>
           <Route path="/portal/policies/new">
             <CustomerPortalPolicyRequest session={session} />

--- a/migrations/0003_add_customer_document_requests.sql
+++ b/migrations/0003_add_customer_document_requests.sql
@@ -1,0 +1,28 @@
+CREATE TYPE document_request_type AS ENUM ('vin_photo', 'odometer_photo', 'diagnosis_report', 'repair_invoice', 'other');
+CREATE TYPE document_request_status AS ENUM ('pending', 'submitted', 'completed', 'cancelled');
+
+CREATE TABLE customer_document_requests (
+    id varchar PRIMARY KEY DEFAULT substring(replace(gen_random_uuid()::text, '-', ''), 1, 8),
+    policy_id varchar NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
+    customer_id varchar NOT NULL REFERENCES customer_accounts(id) ON DELETE CASCADE,
+    requested_by varchar REFERENCES users(id) ON DELETE SET NULL,
+    type document_request_type NOT NULL DEFAULT 'other',
+    title varchar(160) NOT NULL,
+    instructions text,
+    status document_request_status NOT NULL DEFAULT 'pending',
+    due_date timestamp,
+    created_at timestamp DEFAULT now(),
+    updated_at timestamp DEFAULT now()
+);
+
+CREATE TABLE customer_document_uploads (
+    id varchar PRIMARY KEY DEFAULT substring(replace(gen_random_uuid()::text, '-', ''), 1, 8),
+    request_id varchar NOT NULL REFERENCES customer_document_requests(id) ON DELETE CASCADE,
+    customer_id varchar NOT NULL REFERENCES customer_accounts(id) ON DELETE CASCADE,
+    policy_id varchar NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
+    file_name text NOT NULL,
+    file_type text,
+    file_size integer,
+    file_data text NOT NULL,
+    created_at timestamp DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- introduce customer-facing document center with upload workflow and highlights for outstanding requests
- allow admins to create, review, and fulfill document requests with new API endpoints and UI tools
- add database support for document requests/uploads and surface document metrics in the portal overview

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb360b10408330aba25d629724653f