### PR TITLE
Update navigation labels for clarity

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -17,11 +17,11 @@ export default function Navigation({ onGetQuote }: NavigationProps) {
   };
 
   const navLinks = [
-    { href: "/plans", label: "Coverage Plans" },
+    { href: "/plans", label: "Plans" },
     { href: "/about", label: "About" },
     { href: "/faq", label: "FAQ" },
     { href: "/claims", label: "Claims" },
-    { href: "/portal", label: "Customer Portal" },
+    { href: "/portal", label: "Login" },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- rename the Coverage Plans navigation label to Plans for a shorter header entry
- change the Customer Portal navigation label to Login to better fit the header layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd3d7e322c8330990655d4f69011b3