### PR TITLE
Lighten about page theme

### DIFF
--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -14,24 +14,24 @@ import {
 
 export default function About() {
   return (
-    <div className="min-h-screen bg-slate-950">
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 via-white to-slate-100">
       <Navigation onGetQuote={() => {}} />
       <div className="max-w-6xl mx-auto px-4 py-16 space-y-16">
-        <section className="relative overflow-hidden rounded-3xl border border-slate-800 bg-gradient-to-br from-slate-900 via-slate-950 to-black p-12 text-center shadow-2xl">
+        <section className="relative overflow-hidden rounded-3xl border border-blue-100 bg-gradient-to-br from-white via-blue-50 to-blue-100 p-12 text-center shadow-2xl">
           <Sparkles className="absolute -top-6 -left-6 h-24 w-24 text-primary/10" />
           <Sparkles className="absolute -bottom-10 -right-4 h-32 w-32 text-primary/5" />
           <div className="mx-auto max-w-3xl space-y-6">
             <span className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-primary">
               Driven by trust • Powered by protection
             </span>
-            <h1 className="text-4xl font-bold text-white md:text-5xl">
+            <h1 className="text-4xl font-bold text-slate-900 md:text-5xl">
               Peace of mind for every mile you drive.
             </h1>
-            <div className="grid gap-3 text-left text-slate-300 md:grid-cols-2">
-              <p className="rounded-2xl border border-slate-800 bg-black/30 p-4 text-sm font-medium uppercase tracking-wide text-slate-200">
+            <div className="grid gap-3 text-left text-slate-600 md:grid-cols-2">
+              <p className="rounded-2xl border border-blue-100 bg-white/80 p-4 text-sm font-medium uppercase tracking-wide text-slate-700">
                 Specialists in extended vehicle protection plans tailored for real drivers.
               </p>
-              <p className="rounded-2xl border border-slate-800 bg-black/30 p-4 text-sm font-medium uppercase tracking-wide text-slate-200">
+              <p className="rounded-2xl border border-blue-100 bg-white/80 p-4 text-sm font-medium uppercase tracking-wide text-slate-700">
                 Transparent pricing, quick responses, and nationwide repair partnerships you can rely on.
               </p>
             </div>
@@ -39,36 +39,36 @@ export default function About() {
         </section>
 
         <section className="grid gap-6 md:grid-cols-3">
-          <Card className="border-slate-800 bg-slate-900/80">
+          <Card className="border-blue-100 bg-white/90">
             <CardContent className="p-8 text-center space-y-4">
               <Shield className="mx-auto h-12 w-12 text-primary" />
               <div className="space-y-2">
-                <h3 className="text-xl font-semibold text-white">Coverage without confusion</h3>
-                <ul className="space-y-1 text-sm text-slate-300">
+                <h3 className="text-xl font-semibold text-slate-900">Coverage without confusion</h3>
+                <ul className="space-y-1 text-sm text-slate-600">
                   <li>• Engine, transmission, electronics, and luxury tech components</li>
                   <li>• Plans tuned for new daily drivers and seasoned classics alike</li>
                 </ul>
               </div>
             </CardContent>
           </Card>
-          <Card className="border-slate-800 bg-slate-900/80">
+          <Card className="border-blue-100 bg-white/90">
             <CardContent className="p-8 text-center space-y-4">
               <Users className="mx-auto h-12 w-12 text-primary" />
               <div className="space-y-2">
-                <h3 className="text-xl font-semibold text-white">People-first guidance</h3>
-                <ul className="space-y-1 text-sm text-slate-300">
+                <h3 className="text-xl font-semibold text-slate-900">People-first guidance</h3>
+                <ul className="space-y-1 text-sm text-slate-600">
                   <li>• Real humans answering questions in minutes, not hours</li>
                   <li>• Dedicated concierge team for claims and repair scheduling</li>
                 </ul>
               </div>
             </CardContent>
           </Card>
-          <Card className="border-slate-800 bg-slate-900/80">
+          <Card className="border-blue-100 bg-white/90">
             <CardContent className="p-8 text-center space-y-4">
               <Clock className="mx-auto h-12 w-12 text-primary" />
               <div className="space-y-2">
-                <h3 className="text-xl font-semibold text-white">Rapid resolution</h3>
-                <ul className="space-y-1 text-sm text-slate-300">
+                <h3 className="text-xl font-semibold text-slate-900">Rapid resolution</h3>
+                <ul className="space-y-1 text-sm text-slate-600">
                   <li>• Instant roadside assistance &amp; rental support options</li>
                   <li>• Partner network of ASE-certified shops nationwide</li>
                 </ul>
@@ -77,30 +77,30 @@ export default function About() {
           </Card>
         </section>
 
-        <section className="grid gap-8 rounded-3xl border border-slate-800 bg-slate-900/80 p-10 md:grid-cols-[1.2fr_1fr]">
+        <section className="grid gap-8 rounded-3xl border border-blue-100 bg-white/90 p-10 md:grid-cols-[1.2fr_1fr]">
           <div className="space-y-6">
-            <h2 className="text-3xl font-bold text-white">What keeps us in the fast lane</h2>
+            <h2 className="text-3xl font-bold text-slate-900">What keeps us in the fast lane</h2>
             <div className="grid gap-4 md:grid-cols-2">
-              <div className="rounded-2xl border border-slate-800 bg-black/40 p-5">
+              <div className="rounded-2xl border border-blue-100 bg-blue-50 p-5">
                 <Award className="mb-3 h-8 w-8 text-primary" />
-                <h3 className="text-lg font-semibold text-white">15+ years of proven protection</h3>
-                <ul className="mt-3 space-y-1 text-sm text-slate-300">
+                <h3 className="text-lg font-semibold text-slate-900">15+ years of proven protection</h3>
+                <ul className="mt-3 space-y-1 text-sm text-slate-600">
                   <li>• 32,000+ active contracts serviced nationwide</li>
                   <li>• Partnerships with top-rated finance &amp; dealer groups</li>
                 </ul>
               </div>
-              <div className="rounded-2xl border border-slate-800 bg-black/40 p-5">
+              <div className="rounded-2xl border border-blue-100 bg-blue-50 p-5">
                 <HeartHandshake className="mb-3 h-8 w-8 text-primary" />
-                <h3 className="text-lg font-semibold text-white">Promises we keep every day</h3>
-                <ul className="mt-3 space-y-1 text-sm text-slate-300">
+                <h3 className="text-lg font-semibold text-slate-900">Promises we keep every day</h3>
+                <ul className="mt-3 space-y-1 text-sm text-slate-600">
                   <li>• Transparent terms with zero surprise fees</li>
                   <li>• 24/7 claim intake with live status updates</li>
                 </ul>
               </div>
             </div>
-            <div className="grid gap-4 rounded-2xl border border-slate-800 bg-black/30 p-6 text-sm text-slate-200 md:grid-cols-2">
+            <div className="grid gap-4 rounded-2xl border border-blue-100 bg-white/80 p-6 text-sm text-slate-600 md:grid-cols-2">
               <div>
-                <p className="text-xs uppercase tracking-wide text-primary/80">Our north star</p>
+                <p className="text-xs uppercase tracking-wide text-primary">Our north star</p>
                 <ul className="mt-2 space-y-1">
                   <li>• Keep repairs affordable</li>
                   <li>• Keep drivers confident</li>
@@ -108,7 +108,7 @@ export default function About() {
                 </ul>
               </div>
               <div>
-                <p className="text-xs uppercase tracking-wide text-primary/80">How we deliver</p>
+                <p className="text-xs uppercase tracking-wide text-primary">How we deliver</p>
                 <ul className="mt-2 space-y-1">
                   <li>• Real-time plan customization</li>
                   <li>• Concierge claim coordination</li>
@@ -117,53 +117,53 @@ export default function About() {
               </div>
             </div>
           </div>
-          <div className="flex flex-col justify-between gap-6 rounded-2xl border border-slate-800 bg-black/40 p-8 text-left">
-            <h3 className="text-xl font-semibold text-white">Quick company snapshot</h3>
-            <ul className="space-y-4 text-sm text-slate-300">
+          <div className="flex flex-col justify-between gap-6 rounded-2xl border border-blue-100 bg-blue-50 p-8 text-left">
+            <h3 className="text-xl font-semibold text-slate-900">Quick company snapshot</h3>
+            <ul className="space-y-4 text-sm text-slate-600">
               <li>
-                <span className="block text-xs uppercase tracking-wide text-primary/80">Headquarters</span>
+                <span className="block text-xs uppercase tracking-wide text-primary">Headquarters</span>
                 Austin, Texas
               </li>
               <li>
-                <span className="block text-xs uppercase tracking-wide text-primary/80">Founded</span>
+                <span className="block text-xs uppercase tracking-wide text-primary">Founded</span>
                 2009 — family-owned and operated
               </li>
               <li>
-                <span className="block text-xs uppercase tracking-wide text-primary/80">Focus</span>
+                <span className="block text-xs uppercase tracking-wide text-primary">Focus</span>
                 Extended auto warranties, roadside support, rental coverage
               </li>
             </ul>
             <div className="rounded-2xl border border-primary/40 bg-primary/10 p-5 text-left">
               <p className="text-xs uppercase tracking-wide text-primary">Ready when you are</p>
-              <p className="mt-2 text-sm text-white">
+              <p className="mt-2 text-sm text-slate-900">
                 Need a tailored plan? Let us build one that fits your driving style and budget.
               </p>
             </div>
           </div>
         </section>
 
-        <section className="grid gap-6 rounded-3xl border border-slate-800 bg-slate-900/80 p-10 md:grid-cols-2">
+        <section className="grid gap-6 rounded-3xl border border-blue-100 bg-white/90 p-10 md:grid-cols-2">
           <div className="space-y-4">
-            <h2 className="text-3xl font-bold text-white">Visit or connect with us</h2>
-            <p className="text-sm uppercase tracking-wide text-primary/80">Our flagship service center</p>
-            <div className="space-y-3 text-sm text-slate-300">
-              <p className="flex items-center gap-3 rounded-2xl border border-slate-800 bg-black/40 p-4">
+            <h2 className="text-3xl font-bold text-slate-900">Visit or connect with us</h2>
+            <p className="text-sm uppercase tracking-wide text-primary">Our flagship service center</p>
+            <div className="space-y-3 text-sm text-slate-600">
+              <p className="flex items-center gap-3 rounded-2xl border border-blue-100 bg-white/80 p-4">
                 <MapPin className="h-5 w-5 text-primary" />
                 <span>5501 Horizon Park Blvd, Suite 420, Austin, TX 78727</span>
               </p>
-              <p className="flex items-center gap-3 rounded-2xl border border-slate-800 bg-black/40 p-4">
+              <p className="flex items-center gap-3 rounded-2xl border border-blue-100 bg-white/80 p-4">
                 <Phone className="h-5 w-5 text-primary" />
                 <span>Service hotline: (855) 555-2746</span>
               </p>
-              <p className="flex items-center gap-3 rounded-2xl border border-slate-800 bg-black/40 p-4">
+              <p className="flex items-center gap-3 rounded-2xl border border-blue-100 bg-white/80 p-4">
                 <Mail className="h-5 w-5 text-primary" />
                 <span>Support: support@bhautoprotect.com</span>
               </p>
             </div>
           </div>
-          <div className="grid content-between gap-6 rounded-2xl border border-slate-800 bg-black/30 p-8 text-sm text-slate-300">
+          <div className="grid content-between gap-6 rounded-2xl border border-blue-100 bg-white/80 p-8 text-sm text-slate-600">
             <div>
-              <p className="text-xs uppercase tracking-wide text-primary/80">Hours</p>
+              <p className="text-xs uppercase tracking-wide text-primary">Hours</p>
               <ul className="mt-2 space-y-1">
                 <li>• Monday – Friday: 8:00 AM – 7:00 PM CST</li>
                 <li>• Saturday: 9:00 AM – 2:00 PM CST</li>
@@ -171,7 +171,7 @@ export default function About() {
               </ul>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-primary/80">Need help fast?</p>
+              <p className="text-xs uppercase tracking-wide text-primary">Need help fast?</p>
               <ul className="mt-2 space-y-1">
                 <li>• Text “PROTECT” to 41745 for plan updates</li>
                 <li>• Email docs to claims@bhautoprotect.com</li>


### PR DESCRIPTION
## Summary
- restyle the about page with light gradient backgrounds and pastel cards
- update typography colors for readability against the lighter theme

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd40b841a48330b6c4183760d31441