### PR TITLE
Align policy IDs with lead IDs

### DIFF
--- a/migrations/0005_policy_id_matches_lead.sql
+++ b/migrations/0005_policy_id_matches_lead.sql
@@ -1,0 +1,9 @@
+-- Ensure policy identifiers match their associated lead identifiers
+ALTER TABLE policies ALTER COLUMN id DROP DEFAULT;
+
+-- Align existing policy IDs with their lead IDs
+UPDATE policies SET id = lead_id;
+
+-- Remove the no longer used policy ID sequence
+ALTER SEQUENCE IF EXISTS policy_id_seq OWNED BY NONE;
+DROP SEQUENCE IF EXISTS policy_id_seq;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -341,7 +341,10 @@ export class DatabaseStorage implements IStorage {
 
   // Policy operations
   async createPolicy(policyData: InsertPolicy): Promise<Policy> {
-    const [policy] = await db.insert(policies).values(policyData).returning();
+    const [policy] = await db
+      .insert(policies)
+      .values({ ...policyData, id: policyData.leadId })
+      .returning();
     return policy;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -44,7 +44,6 @@ export const documentRequestStatusEnum = pgEnum('document_request_status', [
 
 const shortId = sql`substring(replace(gen_random_uuid()::text, '-', ''), 1, 8)`;
 const leadIdDefault = sql<string>`lpad(nextval('lead_id_seq')::text, 8, '0')`;
-const policyIdDefault = sql<string>`lpad(nextval('policy_id_seq')::text, 8, '0')`;
 
 export const users = pgTable('users', {
   id: varchar('id').primaryKey().default(shortId),
@@ -113,7 +112,7 @@ export const notes = pgTable("notes", {
 });
 
 export const policies = pgTable("policies", {
-  id: varchar("id", { length: 8 }).primaryKey().default(policyIdDefault),
+  id: varchar("id", { length: 8 }).primaryKey(),
   leadId: varchar("lead_id").references(() => leads.id, { onDelete: 'set null' }).notNull(),
   package: varchar("package"),
   expirationMiles: integer("expiration_miles"),


### PR DESCRIPTION
## Summary
- drop the policy ID sequence and default so that policies use the same eight-digit identifier as their lead
- automatically assign the lead's identifier when creating new policies in storage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd43eaea34833088dff3dfe73ecf9e