### PR TITLE
Simplify portal layout and add document request email option

### DIFF
--- a/client/src/pages/portal/index.tsx
+++ b/client/src/pages/portal/index.tsx
@@ -86,43 +86,35 @@ export default function CustomerPortal() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-100">
-      <header className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-slate-950" />
-        <div className="absolute inset-x-0 top-0 h-full bg-gradient-to-br from-primary/30 via-transparent to-slate-900 opacity-80" />
-        <div className="relative">
-          <div className="max-w-6xl mx-auto px-4 py-10">
-            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-              <div className="space-y-3 text-white">
-                <p className="text-xs uppercase tracking-[0.32em] text-white/70">BH Auto Protect</p>
-                <h1 className="text-3xl font-semibold tracking-tight">Welcome back, {displayName || "there"}</h1>
-                <p className="max-w-xl text-sm text-white/70">
-                  Keep your coverage, claims, and paperwork organized in one place. We’ll highlight anything that needs your attention first.
-                </p>
-              </div>
-              <div className="flex items-center gap-4 text-sm text-white/80">
-                <div className="text-right">
-                  <p className="font-medium text-white">{displayName}</p>
-                  {session.customer.displayName && session.customer.displayName !== session.customer.email ? (
-                    <p className="text-white/70">{session.customer.email}</p>
-                  ) : null}
-                </div>
-                <Button variant="outline" onClick={handleLogout} className="border-white/40 bg-white/5 hover:bg-white/10">
-                  Sign out
-                </Button>
-              </div>
+    <div className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs font-medium uppercase tracking-[0.28em] text-slate-400">BH Auto Protect</p>
+            <h1 className="text-2xl font-semibold text-slate-900">Customer portal</h1>
+            <p className="text-sm text-slate-500">Hi {displayName || "there"}! Jump into the page you need and manage one thing at a time.</p>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-slate-600">
+            <div className="text-right">
+              <p className="font-medium text-slate-900">{displayName}</p>
+              {session.customer.displayName && session.customer.displayName !== session.customer.email ? (
+                <p className="text-xs text-slate-500">{session.customer.email}</p>
+              ) : null}
             </div>
+            <Button variant="outline" onClick={handleLogout} className="border-slate-200">
+              Sign out
+            </Button>
           </div>
         </div>
-        <nav className="relative border-t border-white/10 bg-slate-900/60 backdrop-blur">
-          <div className="max-w-6xl mx-auto px-4 py-3 flex flex-wrap gap-2">
+        <nav className="border-t border-slate-200 bg-slate-50/80">
+          <div className="mx-auto flex max-w-5xl flex-wrap gap-2 px-4 py-3">
             {NAV_LINKS.map((link) => (
               <Link key={link.href} href={link.href} className="group">
                 <span
-                  className={`inline-flex items-center rounded-full px-3.5 py-2 text-sm font-medium transition-all ${
+                  className={`inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                     isActiveLink(link.href)
-                      ? "bg-white text-slate-900 shadow"
-                      : "text-white/80 hover:text-white hover:bg-white/10"
+                      ? "bg-slate-900 text-white"
+                      : "text-slate-600 hover:bg-white hover:text-slate-900"
                   }`}
                 >
                   {link.label}
@@ -133,7 +125,7 @@ export default function CustomerPortal() {
         </nav>
       </header>
 
-      <main className="max-w-6xl mx-auto px-4 py-8">
+      <main className="mx-auto max-w-5xl px-4 py-10">
         <Switch>
           <Route path="/portal">
             <CustomerPortalOverview session={session} />

--- a/client/src/pages/portal/overview.tsx
+++ b/client/src/pages/portal/overview.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -14,6 +15,13 @@ import { UploadCloud, CheckCircle2, Clock3 } from "lucide-react";
 
 type Props = {
   session: CustomerSessionSnapshot;
+};
+
+type StatCardProps = {
+  label: string;
+  helper?: string;
+  isLoading?: boolean;
+  value: string;
 };
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -57,6 +65,20 @@ function computeMonthlyTotal(policies: CustomerPolicy[]): number {
 
 function computeOpenClaims(claims: CustomerClaim[]): number {
   return claims.filter((claim) => claim.status !== "claim_covered_closed").length;
+}
+
+function StatCard({ label, helper, isLoading, value }: StatCardProps) {
+  return (
+    <Card className="border-slate-200 bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium text-slate-600">{label}</CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {isLoading ? <Skeleton className="h-7 w-20" /> : <p className="text-2xl font-semibold text-slate-900">{value}</p>}
+        {helper ? <p className="mt-2 text-xs text-slate-500">{helper}</p> : null}
+      </CardContent>
+    </Card>
+  );
 }
 
 export default function CustomerPortalOverview({ session }: Props) {
@@ -108,245 +130,199 @@ export default function CustomerPortalOverview({ session }: Props) {
   }, [outstandingDocuments]);
 
   return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="text-3xl font-bold text-slate-900">Welcome back</h1>
-        <p className="text-slate-600 mt-2">
-          Review your active coverage, keep an eye on open claims, and stay ahead of upcoming payments.
-        </p>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-4">
-        <Card className="border-primary/10 bg-white">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-slate-600">Active Policies</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {policiesQuery.isLoading ? (
-              <Skeleton className="h-8 w-16" />
-            ) : (
-              <p className="text-3xl font-semibold text-slate-900">{policies.length}</p>
-            )}
-            <p className="text-sm text-slate-500 mt-1">Coverage plans linked to your account</p>
-          </CardContent>
-        </Card>
-
-        <Card className="border-amber-200 bg-amber-50/60">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-amber-700">Open Claims</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {claimsQuery.isLoading ? (
-              <Skeleton className="h-8 w-16" />
-            ) : (
-              <p className="text-3xl font-semibold text-amber-900">{activeClaims}</p>
-            )}
-            <p className="text-sm text-amber-700/80 mt-1">We’ll keep you updated every step of the way</p>
-          </CardContent>
-        </Card>
-
-        <Card className="border-emerald-200 bg-emerald-50/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-emerald-700">Monthly Coverage</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {policiesQuery.isLoading ? (
-              <Skeleton className="h-8 w-24" />
-            ) : (
-              <p className="text-3xl font-semibold text-emerald-900">
-                {monthlyTotal > 0 ? currencyFormatter.format(monthlyTotal) : "—"}
-              </p>
-            )}
-            <p className="text-sm text-emerald-700/80 mt-1">Estimated monthly payment across all policies</p>
-          </CardContent>
-        </Card>
-
-        <Card className="border-sky-200 bg-sky-50/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-sky-700">Document Tasks</CardTitle>
-          </CardHeader>
-          <CardContent>
+    <div className="space-y-10">
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Action center</h2>
+            <p className="text-sm text-slate-500">
+              Anything listed here needs a quick upload. Tap to jump straight to the documents page.
+            </p>
+          </div>
+          <Link href="/portal/documents" className="text-sm font-medium text-primary">
+            View documents
+          </Link>
+        </div>
+        <Card className="border-slate-200 bg-white">
+          <CardContent className="space-y-4 py-5 text-sm text-slate-600">
             {documentsQuery.isLoading ? (
-              <Skeleton className="h-8 w-16" />
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-1/2" />
+                <Skeleton className="h-5 w-2/3" />
+              </div>
+            ) : outstandingDocuments.length === 0 ? (
+              <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
+                <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                <div>
+                  <p className="font-medium text-slate-800">You’re all caught up</p>
+                  <p className="text-xs text-slate-500">We’ll nudge you here as soon as something new comes in.</p>
+                </div>
+              </div>
             ) : (
-              <p className="text-3xl font-semibold text-sky-900">{outstandingDocuments.length}</p>
+              <ul className="space-y-3">
+                {outstandingDocuments.slice(0, 3).map((request) => (
+                  <li key={request.id}>
+                    <Link
+                      href={`/portal/documents?request=${request.id}`}
+                      className="group block rounded-md border border-slate-200 bg-white px-4 py-3 transition hover:border-primary hover:bg-primary/5"
+                    >
+                      <div className="flex items-start gap-3">
+                        <UploadCloud className="mt-1 h-4 w-4 text-primary" />
+                        <div className="space-y-1">
+                          <p className="font-medium text-slate-900 group-hover:text-primary">{request.title}</p>
+                          <p className="text-xs text-slate-500">
+                            {DOCUMENT_REQUEST_TYPE_COPY[request.type].label} • {summarizeDocumentVehicle(request.policy)}
+                          </p>
+                          <p className="text-xs text-slate-500">
+                            {request.dueDate ? (
+                              <span className="inline-flex items-center gap-1 text-amber-600">
+                                <Clock3 className="h-3.5 w-3.5" /> Due {formatDate(request.dueDate)}
+                              </span>
+                            ) : (
+                              "Send when you can"
+                            )}
+                          </p>
+                        </div>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+                {outstandingDocuments.length > 3 ? (
+                  <li className="rounded-md border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
+                    {outstandingDocuments.length - 3} more request(s) are waiting in Documents.
+                  </li>
+                ) : null}
+              </ul>
             )}
-            <p className="text-sm text-sky-700/80 mt-1">
-              {outstandingDocuments.length === 0
-                ? "No uploads needed right now"
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold text-slate-900">At a glance</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            label="Active policies"
+            value={String(policies.length)}
+            helper="Coverage connected to your login"
+            isLoading={policiesQuery.isLoading}
+          />
+          <StatCard
+            label="Open claims"
+            value={String(activeClaims)}
+            helper="We’ll let you know as they move forward"
+            isLoading={claimsQuery.isLoading}
+          />
+          <StatCard
+            label="Monthly coverage"
+            value={monthlyTotal > 0 ? currencyFormatter.format(monthlyTotal) : "—"}
+            helper="Estimated recurring payment"
+            isLoading={policiesQuery.isLoading}
+          />
+          <StatCard
+            label="Document tasks"
+            value={String(outstandingDocuments.length)}
+            helper={
+              outstandingDocuments.length === 0
+                ? "Nothing pending right now"
                 : nextDocumentDue
                   ? `Next due ${formatDate(nextDocumentDue)}`
-                  : "We’ll review files as soon as you send them"}
-            </p>
-          </CardContent>
-        </Card>
-      </div>
+                  : "Upload whenever you’re ready"
+            }
+            isLoading={documentsQuery.isLoading}
+          />
+        </div>
+      </section>
 
-      <Card className="border-slate-200 bg-white/70 shadow-sm">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base text-slate-800">
-            <UploadCloud className="h-4 w-4 text-primary" />
-            Action center
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4 text-sm text-slate-600">
-          {documentsQuery.isLoading ? (
-            <div className="space-y-2">
-              <Skeleton className="h-5 w-1/2" />
-              <Skeleton className="h-5 w-2/3" />
-            </div>
-          ) : outstandingDocuments.length === 0 ? (
-            <div className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50/80 px-4 py-3">
-              <CheckCircle2 className="h-5 w-5 text-emerald-500" />
-              <div>
-                <p className="font-medium text-slate-800">You’re all caught up</p>
-                <p className="text-xs text-slate-500">We’ll notify you here whenever new documents are needed.</p>
-              </div>
-            </div>
-          ) : (
-            <ul className="space-y-3">
-              {outstandingDocuments.slice(0, 2).map((request) => (
-                <li
-                  key={request.id}
-                  className="flex items-start gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm"
-                >
-                  <div className="mt-1">
-                    <UploadCloud className="h-4 w-4 text-primary" />
-                  </div>
-                  <div className="space-y-1">
-                    <p className="font-medium text-slate-800">{request.title}</p>
-                    <p className="text-xs text-slate-500">
-                      {DOCUMENT_REQUEST_TYPE_COPY[request.type].label} • {summarizeDocumentVehicle(request.policy)}
-                    </p>
-                    <p className="text-xs text-slate-500">
-                      {request.dueDate ? (
-                        <span className="inline-flex items-center gap-1 text-amber-600">
-                          <Clock3 className="h-3.5 w-3.5" /> Due {formatDate(request.dueDate)}
-                        </span>
-                      ) : (
-                        "Send when ready"
-                      )}
-                    </p>
-                  </div>
-                </li>
-              ))}
-              {outstandingDocuments.length > 2 ? (
-                <li className="rounded-lg border border-dashed border-slate-200 bg-white px-4 py-3 text-xs text-slate-500">
-                  {outstandingDocuments.length - 2} more request(s) waiting in the Documents tab.
-                </li>
-              ) : null}
-            </ul>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Your Coverage Details</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {policiesQuery.isLoading ? (
-            <div className="space-y-3">
-              <Skeleton className="h-20 w-full" />
-              <Skeleton className="h-20 w-full" />
-            </div>
-          ) : policies.length === 0 ? (
-            <p className="text-sm text-slate-500">
-              We haven’t linked any policies yet. If you recently purchased coverage, give us a day to finish the setup
-              or request access using the “Add Coverage” tab.
-            </p>
-          ) : (
-            <div className="space-y-4">
-              {policies.map((policy) => (
-                <div
-                  key={policy.id}
-                  className="border border-slate-200 rounded-xl p-4 md:p-6 bg-gradient-to-br from-white via-slate-50 to-white"
-                >
-                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Coverage on file</h2>
+          <p className="text-sm text-slate-500">Quick reference for each vehicle you’ve protected with BH Auto Protect.</p>
+        </div>
+        {policiesQuery.isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : policies.length === 0 ? (
+          <Card className="border-slate-200 bg-white">
+            <CardContent className="py-6 text-sm text-slate-600">
+              We haven’t linked any policies yet. Recently purchased coverage may take up to one business day to appear. You can request access from the Add Coverage page.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {policies.map((policy) => (
+              <Card key={policy.id} className="border-slate-200 bg-white">
+                <CardContent className="space-y-4 py-5">
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                     <div>
-                      <h3 className="text-lg font-semibold text-slate-900">{summarizeVehicle(policy)}</h3>
-                      <p className="text-sm text-slate-500">
-                        Policy #{policy.id}
-                      </p>
+                      <p className="text-base font-semibold text-slate-900">{summarizeVehicle(policy)}</p>
+                      <p className="text-xs text-slate-500">Policy #{policy.id}</p>
                     </div>
-                    <Badge className="w-fit" variant="secondary">
-                      {friendlyPlanName(policy.package)} Plan
+                    <Badge variant="secondary" className="w-fit">
+                      {friendlyPlanName(policy.package)} plan
                     </Badge>
                   </div>
-                  <div className="grid md:grid-cols-4 gap-4 mt-4 text-sm text-slate-600">
+                  <div className="grid gap-3 text-sm text-slate-600 md:grid-cols-4">
                     <div>
-                      <p className="font-semibold text-slate-700">Coverage start</p>
+                      <p className="font-medium text-slate-700">Coverage start</p>
                       <p>{formatDate(policy.policyStartDate)}</p>
                     </div>
                     <div>
-                      <p className="font-semibold text-slate-700">Expires</p>
+                      <p className="font-medium text-slate-700">Expires</p>
                       <p>{formatDate(policy.expirationDate)}</p>
                     </div>
                     <div>
-                      <p className="font-semibold text-slate-700">Deductible</p>
+                      <p className="font-medium text-slate-700">Deductible</p>
                       <p>{policy.deductible != null ? currencyFormatter.format(policy.deductible) : "On file"}</p>
                     </div>
                     <div>
-                      <p className="font-semibold text-slate-700">Monthly payment</p>
-                      <p>
-                        {policy.monthlyPayment != null
-                          ? currencyFormatter.format(policy.monthlyPayment)
-                          : "On file"}
-                      </p>
+                      <p className="font-medium text-slate-700">Monthly payment</p>
+                      <p>{policy.monthlyPayment != null ? currencyFormatter.format(policy.monthlyPayment) : "On file"}</p>
                     </div>
                   </div>
-                  <div className="mt-4 text-sm text-slate-500">
-                    <p>
-                      Questions about your coverage? Reach us anytime at{' '}
-                      <a className="text-primary font-medium" href="tel:18882001234">
-                        1 (888) 200-1234
-                      </a>{' '}
-                      or email{' '}
-                      <a className="text-primary font-medium" href="mailto:support@bhautoprotect.com">
-                        support@bhautoprotect.com
-                      </a>
-                      .
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </section>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Recent Claim Activity</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {claimsQuery.isLoading ? (
-            <Skeleton className="h-24 w-full" />
-          ) : claims.length === 0 ? (
-            <p className="text-sm text-slate-500">
-              You don’t have any claims in progress. If your vehicle needs attention, head to the Claims tab to start a
-              new request.
-            </p>
-          ) : (
-            <div className="space-y-3">
-              {claims.slice(0, 3).map((claim) => (
-                <div key={claim.id} className="border border-slate-200 rounded-lg p-4">
-                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-semibold text-slate-800">Claim #{claim.id}</p>
-                      <p className="text-xs text-slate-500">Filed {formatDate(claim.createdAt)}</p>
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Recent claim updates</h2>
+          <p className="text-sm text-slate-500">
+            Here’s what’s currently open. Head to the Claims page to view history or start something new.
+          </p>
+        </div>
+        <Card className="border-slate-200 bg-white">
+          <CardContent className="py-5">
+            {claimsQuery.isLoading ? (
+              <Skeleton className="h-24 w-full" />
+            ) : claims.length === 0 ? (
+              <p className="text-sm text-slate-600">You don’t have any claims in progress right now.</p>
+            ) : (
+              <ul className="space-y-3">
+                {claims.slice(0, 3).map((claim) => (
+                  <li key={claim.id} className="rounded-md border border-slate-200 px-4 py-3">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                      <div>
+                        <p className="text-sm font-medium text-slate-900">Claim #{claim.id}</p>
+                        <p className="text-xs text-slate-500">Filed {formatDate(claim.createdAt)}</p>
+                      </div>
+                      <Badge variant="outline" className="capitalize">
+                        {claim.status.replace(/_/g, " ")}
+                      </Badge>
                     </div>
-                    <Badge variant="outline" className="capitalize">
-                      {claim.status.replace(/_/g, ' ')}
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-slate-600 mt-3 line-clamp-2">{claim.message}</p>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                    <p className="mt-2 text-sm text-slate-600 line-clamp-2">{claim.message}</p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- streamline the customer portal shell and overview cards into a cleaner layout, including clickable action center items
- highlight targeted document requests when opening the documents page so customers can jump straight to the right card
- let admins email customers when creating document requests and send a branded message with instructions and a direct upload link

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd4b91a5188330806e0faa79cc3ee7