### PR TITLE
Extend session lifetime for admin and customer portals

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -783,7 +783,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   const MemoryStore = createMemoryStore(session);
   const secureCookie = process.env.NODE_ENV === "production";
-  const sessionStore = new MemoryStore({ checkPeriod: 24 * 60 * 60 * 1000 });
+  const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+  const sessionStore = new MemoryStore({ checkPeriod: THIRTY_DAYS_MS, ttl: THIRTY_DAYS_MS });
 
   app.set("trust proxy", 1);
   app.use(
@@ -793,11 +794,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       resave: false,
       saveUninitialized: false,
       store: sessionStore,
+      rolling: true,
       cookie: {
         httpOnly: true,
         sameSite: "lax",
         secure: secureCookie,
-        maxAge: 12 * 60 * 60 * 1000,
+        maxAge: THIRTY_DAYS_MS,
       },
     })
   );


### PR DESCRIPTION
## Summary
- increase the session cookie lifetime used by both admin and customer portals to 30 days
- refresh cookie expiration on each request and align the in-memory session TTL so active users remain signed in

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd524689948330b7b5c8f8ead8d072