### PR TITLE
Enhance payment workflows and expose charge history

### DIFF
--- a/client/src/lib/customer-auth.ts
+++ b/client/src/lib/customer-auth.ts
@@ -63,7 +63,25 @@ export type CustomerPaymentProfile = {
   paymentMethod: string | null;
   accountName: string | null;
   accountIdentifier: string | null;
+  cardBrand: string | null;
+  cardLastFour: string | null;
+  cardExpiryMonth: number | null;
+  cardExpiryYear: number | null;
+  billingZip: string | null;
   autopayEnabled: boolean;
+  notes: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+};
+
+export type PolicyCharge = {
+  id: string;
+  policyId: string;
+  customerId: string | null;
+  description: string;
+  amountCents: number;
+  status: 'pending' | 'processing' | 'paid' | 'failed' | 'refunded';
+  chargedAt: string;
   notes: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;

--- a/client/src/pages/portal/payments.tsx
+++ b/client/src/pages/portal/payments.tsx
@@ -6,11 +6,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   fetchCustomerJson,
   type CustomerSessionSnapshot,
   type CustomerPolicy,
   type CustomerPaymentProfile,
+  type PolicyCharge,
 } from "@/lib/customer-auth";
 import { useToast } from "@/hooks/use-toast";
 
@@ -22,6 +24,11 @@ type PaymentFormState = {
   paymentMethod: string;
   accountName: string;
   accountIdentifier: string;
+  cardBrand: string;
+  cardLastFour: string;
+  cardExpiryMonth: string;
+  cardExpiryYear: string;
+  billingZip: string;
   autopayEnabled: boolean;
   notes: string;
 };
@@ -30,6 +37,11 @@ const initialForm: PaymentFormState = {
   paymentMethod: "",
   accountName: "",
   accountIdentifier: "",
+  cardBrand: "",
+  cardLastFour: "",
+  cardExpiryMonth: "",
+  cardExpiryYear: "",
+  billingZip: "",
   autopayEnabled: false,
   notes: "",
 };
@@ -44,16 +56,36 @@ function describePolicy(policy: CustomerPolicy): string {
   return summary ? `${summary} · ${policy.id}` : `Policy ${policy.id}`;
 }
 
+const currencyFormatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+
+const chargeStatusCopy: Record<PolicyCharge["status"], { label: string; className: string }> = {
+  pending: { label: "Pending", className: "bg-amber-100 text-amber-700 border-transparent" },
+  processing: { label: "Processing", className: "bg-blue-100 text-blue-700 border-transparent" },
+  paid: { label: "Paid", className: "bg-emerald-100 text-emerald-700 border-transparent" },
+  failed: { label: "Failed", className: "bg-rose-100 text-rose-700 border-transparent" },
+  refunded: { label: "Refunded", className: "bg-slate-100 text-slate-700 border-transparent" },
+};
+
+function formatChargeDate(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return "";
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
 function PaymentCard({
   policy,
   profile,
   onSave,
   saving,
+  charges,
+  chargesLoading,
 }: {
   policy: CustomerPolicy;
   profile: CustomerPaymentProfile | undefined;
   onSave: (form: PaymentFormState) => void;
   saving: boolean;
+  charges: PolicyCharge[];
+  chargesLoading: boolean;
 }) {
   const [form, setForm] = useState<PaymentFormState>(initialForm);
 
@@ -66,6 +98,11 @@ function PaymentCard({
       paymentMethod: profile.paymentMethod ?? "",
       accountName: profile.accountName ?? "",
       accountIdentifier: profile.accountIdentifier ?? "",
+      cardBrand: profile.cardBrand ?? "",
+      cardLastFour: profile.cardLastFour ?? "",
+      cardExpiryMonth: profile.cardExpiryMonth != null ? String(profile.cardExpiryMonth).padStart(2, "0") : "",
+      cardExpiryYear: profile.cardExpiryYear != null ? String(profile.cardExpiryYear) : "",
+      billingZip: profile.billingZip ?? "",
       autopayEnabled: profile.autopayEnabled,
       notes: profile.notes ?? "",
     });
@@ -76,70 +113,234 @@ function PaymentCard({
     onSave(form);
   };
 
+  const previewBrand = form.cardBrand || profile?.cardBrand || form.paymentMethod || profile?.paymentMethod || "Card on file";
+  const previewLastFour = form.cardLastFour || profile?.cardLastFour || profile?.accountIdentifier || "••••";
+  const previewExpiry = (() => {
+    const month = form.cardExpiryMonth || (profile?.cardExpiryMonth != null ? String(profile.cardExpiryMonth).padStart(2, "0") : "");
+    const year = form.cardExpiryYear || (profile?.cardExpiryYear != null ? String(profile.cardExpiryYear).slice(-2) : "");
+    return month && year ? `${month}/${year}` : "MM/YY";
+  })();
+  const previewName =
+    form.accountName ||
+    profile?.accountName ||
+    [policy.lead?.firstName, policy.lead?.lastName].filter(Boolean).join(" ") ||
+    "Authorized payer";
+
+  const recentCharges = charges.slice(0, 6);
+
   return (
     <Card key={policy.id} className="border border-slate-200 shadow-sm">
-      <CardHeader>
-        <CardTitle className="text-lg text-slate-900">{describePolicy(policy)}</CardTitle>
+      <CardHeader className="space-y-1">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle className="text-lg text-slate-900">{describePolicy(policy)}</CardTitle>
+          <Badge variant="outline" className={form.autopayEnabled ? "border-emerald-200 bg-emerald-50 text-emerald-700" : "border-slate-200 bg-slate-100 text-slate-700"}>
+            {form.autopayEnabled ? "Autopay enabled" : "Autopay off"}
+          </Badge>
+        </div>
+        <p className="text-sm text-slate-500">
+          Securely share the card our billing specialists should use. We only store the pieces we need to verify with you by
+          phone before any charge is processed.
+        </p>
       </CardHeader>
-      <CardContent>
-        <form className="space-y-4" onSubmit={handleSubmit}>
-          <div className="grid md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor={`method-${policy.id}`}>Payment method</Label>
-              <Input
-                id={`method-${policy.id}`}
-                placeholder="Visa ending in 1234, ACH, etc."
-                value={form.paymentMethod}
-                onChange={(event) => setForm((current) => ({ ...current, paymentMethod: event.target.value }))}
+      <CardContent className="space-y-6">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,320px)_1fr]">
+          <div className="relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-900 via-indigo-600 to-slate-900 p-6 text-white shadow-sm">
+            <div className="flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-300">
+              <span>BH AUTOPROTECT</span>
+              <span>{policy.id}</span>
+            </div>
+            <div className="mt-8 text-sm text-slate-200">{previewBrand}</div>
+            <div className="mt-3 text-2xl font-semibold tracking-[0.32em] text-white">•••• {previewLastFour || "••••"}</div>
+            <div className="mt-6 flex items-center justify-between text-xs text-slate-300">
+              <div>
+                <p className="font-semibold text-slate-100">Cardholder</p>
+                <p className="mt-1 text-sm text-slate-200">{previewName}</p>
+              </div>
+              <div className="text-right">
+                <p className="font-semibold text-slate-100">Expires</p>
+                <p className="mt-1 text-sm text-slate-200">{previewExpiry}</p>
+              </div>
+            </div>
+            <div className="pointer-events-none absolute -right-12 -top-12 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
+          </div>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor={`method-${policy.id}`}>Card nickname</Label>
+                <Input
+                  id={`method-${policy.id}`}
+                  placeholder="Primary business card"
+                  value={form.paymentMethod}
+                  onChange={(event) => setForm((current) => ({ ...current, paymentMethod: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`brand-${policy.id}`}>Card brand</Label>
+                <Input
+                  id={`brand-${policy.id}`}
+                  placeholder="Visa, Mastercard, AmEx"
+                  value={form.cardBrand}
+                  onChange={(event) => setForm((current) => ({ ...current, cardBrand: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor={`name-${policy.id}`}>Name on card</Label>
+                <Input
+                  id={`name-${policy.id}`}
+                  placeholder="Who should we bill?"
+                  value={form.accountName}
+                  onChange={(event) => setForm((current) => ({ ...current, accountName: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`identifier-${policy.id}`}>Internal reference</Label>
+                <Input
+                  id={`identifier-${policy.id}`}
+                  placeholder="Invoice or account #"
+                  value={form.accountIdentifier}
+                  onChange={(event) => setForm((current) => ({ ...current, accountIdentifier: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              <div className="space-y-2">
+                <Label htmlFor={`last-four-${policy.id}`}>Last four digits</Label>
+                <Input
+                  id={`last-four-${policy.id}`}
+                  placeholder="1234"
+                  inputMode="numeric"
+                  maxLength={4}
+                  value={form.cardLastFour}
+                  onChange={(event) => {
+                    const value = event.target.value.replace(/[^0-9]/g, "").slice(0, 4);
+                    setForm((current) => ({ ...current, cardLastFour: value }));
+                  }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`exp-month-${policy.id}`}>Exp. month</Label>
+                <Input
+                  id={`exp-month-${policy.id}`}
+                  placeholder="MM"
+                  inputMode="numeric"
+                  maxLength={2}
+                  value={form.cardExpiryMonth}
+                  onChange={(event) => {
+                    const value = event.target.value.replace(/[^0-9]/g, "").slice(0, 2);
+                    setForm((current) => ({ ...current, cardExpiryMonth: value }));
+                  }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`exp-year-${policy.id}`}>Exp. year</Label>
+                <Input
+                  id={`exp-year-${policy.id}`}
+                  placeholder="YYYY"
+                  inputMode="numeric"
+                  maxLength={4}
+                  value={form.cardExpiryYear}
+                  onChange={(event) => {
+                    const value = event.target.value.replace(/[^0-9]/g, "").slice(0, 4);
+                    setForm((current) => ({ ...current, cardExpiryYear: value }));
+                  }}
+                />
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor={`zip-${policy.id}`}>Billing ZIP</Label>
+                <Input
+                  id={`zip-${policy.id}`}
+                  placeholder="12345"
+                  inputMode="numeric"
+                  maxLength={10}
+                  value={form.billingZip}
+                  onChange={(event) => setForm((current) => ({ ...current, billingZip: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`notes-${policy.id}`}>Notes for our team</Label>
+                <Textarea
+                  id={`notes-${policy.id}`}
+                  rows={4}
+                  placeholder="Payment timing, shared cards, or special handling"
+                  value={form.notes}
+                  onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between rounded-lg border border-slate-200 p-3">
+              <div>
+                <p className="text-sm font-medium text-slate-800">Autopay</p>
+                <p className="text-xs text-slate-500">
+                  Let us draft each payment automatically once everything is verified.
+                </p>
+              </div>
+              <Switch
+                checked={form.autopayEnabled}
+                onCheckedChange={(checked) => setForm((current) => ({ ...current, autopayEnabled: checked }))}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor={`name-${policy.id}`}>Name on account</Label>
-              <Input
-                id={`name-${policy.id}`}
-                placeholder="Who should we bill?"
-                value={form.accountName}
-                onChange={(event) => setForm((current) => ({ ...current, accountName: event.target.value }))}
-              />
+            <Button type="submit" disabled={saving} className="w-full md:w-auto">
+              {saving ? "Saving..." : "Save card details"}
+            </Button>
+          </form>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-slate-900">Recent charges</h3>
+            {recentCharges.length > 0 ? (
+              <span className="text-xs text-slate-500">Showing {recentCharges.length} of {charges.length}</span>
+            ) : null}
+          </div>
+          {chargesLoading ? (
+            <div className="rounded-lg border border-dashed border-slate-200 px-4 py-6 text-center text-xs text-slate-500">
+              Loading charge history...
             </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor={`identifier-${policy.id}`}>Billing identifier</Label>
-            <Input
-              id={`identifier-${policy.id}`}
-              placeholder="Last four digits or billing reference"
-              value={form.accountIdentifier}
-              onChange={(event) => setForm((current) => ({ ...current, accountIdentifier: event.target.value }))}
-            />
-            <p className="text-xs text-slate-500">
-              We only store the last few digits of your payment details. A specialist will confirm the full information over
-              the phone before charging anything.
-            </p>
-          </div>
-          <div className="flex items-center justify-between rounded-lg border border-slate-200 p-3">
-            <div>
-              <p className="text-sm font-medium text-slate-800">Autopay</p>
-              <p className="text-xs text-slate-500">Enable recurring payments once everything is set up.</p>
+          ) : recentCharges.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-slate-200 px-4 py-6 text-center text-xs text-slate-500">
+              Once we post charges for this policy, you’ll see them itemized here.
             </div>
-            <Switch
-              checked={form.autopayEnabled}
-              onCheckedChange={(checked) => setForm((current) => ({ ...current, autopayEnabled: checked }))}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor={`notes-${policy.id}`}>Notes for our billing team</Label>
-            <Textarea
-              id={`notes-${policy.id}`}
-              rows={4}
-              placeholder="Share billing preferences, special instructions, or timing requests."
-              value={form.notes}
-              onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))}
-            />
-          </div>
-          <Button type="submit" disabled={saving}>
-            {saving ? "Saving..." : "Save payment preferences"}
-          </Button>
-        </form>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-slate-200">
+              <table className="min-w-full divide-y divide-slate-200 text-sm">
+                <thead className="bg-slate-50 text-xs font-medium uppercase tracking-wide text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Description</th>
+                    <th className="px-4 py-3 text-left">Date</th>
+                    <th className="px-4 py-3 text-left">Status</th>
+                    <th className="px-4 py-3 text-right">Amount</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 bg-white">
+                  {recentCharges.map((charge) => {
+                    const status = chargeStatusCopy[charge.status];
+                    return (
+                      <tr key={charge.id}>
+                        <td className="px-4 py-3">
+                          <div className="font-medium text-slate-900">{charge.description}</div>
+                          {charge.notes ? <div className="text-xs text-slate-500">{charge.notes}</div> : null}
+                        </td>
+                        <td className="px-4 py-3 text-slate-600">{formatChargeDate(charge.chargedAt)}</td>
+                        <td className="px-4 py-3">
+                          <Badge variant="outline" className={status.className}>
+                            {status.label}
+                          </Badge>
+                        </td>
+                        <td className="px-4 py-3 text-right font-semibold text-slate-900">
+                          {currencyFormatter.format((charge.amountCents ?? 0) / 100)}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
       </CardContent>
     </Card>
   );
@@ -154,6 +355,9 @@ export default function CustomerPortalPayments({ session }: Props) {
   ]);
   const paymentProfilesQuery = useQuery<{ data?: { paymentProfiles?: CustomerPaymentProfile[] } }>([
     "/api/customer/payment-profiles",
+  ]);
+  const chargesQuery = useQuery<{ data?: { charges?: PolicyCharge[] } }>([
+    "/api/customer/payment-charges",
   ]);
 
   const policies = useMemo(() => {
@@ -173,12 +377,32 @@ export default function CustomerPortalPayments({ session }: Props) {
     return map;
   }, [paymentProfilesQuery.data]);
 
+  const chargesByPolicy = useMemo(() => {
+    const charges = chargesQuery.data?.data?.charges ?? [];
+    const map = new Map<string, PolicyCharge[]>();
+    for (const charge of charges) {
+      const existing = map.get(charge.policyId) ?? [];
+      existing.push(charge);
+      map.set(charge.policyId, existing);
+    }
+    for (const [policyId, list] of map) {
+      list.sort((a, b) => new Date(b.chargedAt).valueOf() - new Date(a.chargedAt).valueOf());
+      map.set(policyId, list);
+    }
+    return map;
+  }, [chargesQuery.data]);
+
   const mutation = useMutation({
     mutationFn: async ({ policyId, form }: { policyId: string; form: PaymentFormState }) => {
       const payload: Record<string, unknown> = {
         paymentMethod: form.paymentMethod.trim() || undefined,
         accountName: form.accountName.trim() || undefined,
         accountIdentifier: form.accountIdentifier.trim() || undefined,
+        cardBrand: form.cardBrand.trim() || undefined,
+        cardLastFour: form.cardLastFour.trim() || undefined,
+        cardExpiryMonth: form.cardExpiryMonth ? Number(form.cardExpiryMonth) : undefined,
+        cardExpiryYear: form.cardExpiryYear ? Number(form.cardExpiryYear) : undefined,
+        billingZip: form.billingZip.trim() || undefined,
         autopayEnabled: form.autopayEnabled,
         notes: form.notes.trim() || undefined,
       };
@@ -206,9 +430,9 @@ export default function CustomerPortalPayments({ session }: Props) {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-3xl font-bold text-slate-900">Payment Preferences</h1>
+        <h1 className="text-3xl font-bold text-slate-900">Payment Center</h1>
         <p className="text-slate-600 mt-2">
-          Manage the details our billing team will use when collecting your monthly coverage payments.
+          Keep your preferred card on file, enable autopay, and review every charge tied to your protection plan.
         </p>
       </div>
 
@@ -227,6 +451,8 @@ export default function CustomerPortalPayments({ session }: Props) {
               policy={policy}
               profile={profilesByPolicy.get(policy.id)}
               saving={mutation.isLoading}
+              charges={chargesByPolicy.get(policy.id) ?? []}
+              chargesLoading={chargesQuery.isLoading}
               onSave={(form) => mutation.mutate({ policyId: policy.id, form })}
             />
           ))

--- a/migrations/0006_enhanced_payment_tracking.sql
+++ b/migrations/0006_enhanced_payment_tracking.sql
@@ -1,0 +1,29 @@
+DO $$
+BEGIN
+  CREATE TYPE policy_charge_status AS ENUM ('pending','processing','paid','failed','refunded');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE customer_payment_profiles
+  ADD COLUMN IF NOT EXISTS card_brand varchar(40),
+  ADD COLUMN IF NOT EXISTS card_last_four varchar(4),
+  ADD COLUMN IF NOT EXISTS card_expiry_month integer,
+  ADD COLUMN IF NOT EXISTS card_expiry_year integer,
+  ADD COLUMN IF NOT EXISTS billing_zip varchar(16);
+
+CREATE TABLE IF NOT EXISTS policy_charges (
+  id varchar(8) PRIMARY KEY DEFAULT substring(replace(gen_random_uuid()::text, '-', ''), 1, 8),
+  policy_id varchar(8) NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
+  customer_id varchar REFERENCES customer_accounts(id) ON DELETE SET NULL,
+  description text NOT NULL,
+  amount_cents integer NOT NULL,
+  status policy_charge_status NOT NULL DEFAULT 'pending',
+  charged_at timestamp NOT NULL DEFAULT now(),
+  notes text,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS policy_charges_policy_id_idx ON policy_charges(policy_id);
+CREATE INDEX IF NOT EXISTS policy_charges_customer_id_idx ON policy_charges(customer_id);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -984,15 +984,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
     preferredPhone: z.string().trim().min(7).max(40).optional(),
   });
 
+  const currentYear = new Date().getFullYear();
+  const maxCardExpiryYear = currentYear + 20;
+
   const customerPaymentProfileSchema = z.object({
     paymentMethod: z.string().trim().max(120).optional(),
     accountName: z.string().trim().max(120).optional(),
     accountIdentifier: z.string().trim().max(120).optional(),
+    cardBrand: z.string().trim().max(40).optional(),
+    cardLastFour: z
+      .string()
+      .trim()
+      .regex(/^[0-9]{2,4}$/, 'Enter the last 2-4 digits on the card')
+      .optional(),
+    cardExpiryMonth: z.coerce.number().int().min(1).max(12).optional(),
+    cardExpiryYear: z.coerce
+      .number()
+      .int()
+      .min(currentYear)
+      .max(maxCardExpiryYear)
+      .optional(),
+    billingZip: z.string().trim().min(3).max(16).optional(),
     autopayEnabled: z.boolean().optional(),
     notes: z.string().trim().max(2000).optional(),
   });
-
-  const currentYear = new Date().getFullYear();
   const customerPolicyRequestSchema = z.object({
     message: z.string().trim().min(1, 'Please include a short note so our team knows how to help').max(2000),
     phone: z.string().trim().min(7).max(40).optional(),
@@ -1358,6 +1373,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         paymentMethod: update.paymentMethod?.trim() || undefined,
         accountName: update.accountName?.trim() || undefined,
         accountIdentifier: update.accountIdentifier?.trim() || undefined,
+        cardBrand: update.cardBrand?.trim() || undefined,
+        cardLastFour: update.cardLastFour?.trim() || undefined,
+        cardExpiryMonth: update.cardExpiryMonth ?? undefined,
+        cardExpiryYear: update.cardExpiryYear ?? undefined,
+        billingZip: update.billingZip?.trim() || undefined,
         autopayEnabled: update.autopayEnabled ?? false,
         notes: update.notes?.trim() || undefined,
       });
@@ -1370,6 +1390,36 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
       console.error('Error updating payment profile:', error);
       res.status(500).json({ message: 'Failed to save payment information' });
+    }
+  });
+
+  app.get('/api/customer/payment-charges', customerAuth, async (_req, res) => {
+    try {
+      const account = res.locals.customerAccount as CustomerAccount;
+      const charges = await storage.listCustomerCharges(account.id);
+      res.json({ data: { charges }, message: 'Charges retrieved successfully' });
+    } catch (error) {
+      console.error('Error loading customer charges:', error);
+      res.status(500).json({ message: 'Failed to load charges' });
+    }
+  });
+
+  app.get('/api/customer/policies/:id/charges', customerAuth, async (req, res) => {
+    try {
+      const account = res.locals.customerAccount as CustomerAccount;
+      const policyId = req.params.id;
+      const policies = await storage.getCustomerPolicies(account.id);
+      const hasPolicy = policies.some((policy) => policy.id === policyId);
+      if (!hasPolicy) {
+        res.status(404).json({ message: 'Policy not found' });
+        return;
+      }
+
+      const charges = await storage.listPolicyCharges(policyId);
+      res.json({ data: { charges }, message: 'Charges retrieved successfully' });
+    } catch (error) {
+      console.error('Error loading policy charges for customer:', error);
+      res.status(500).json({ message: 'Failed to load charges' });
     }
   });
 
@@ -2357,6 +2407,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Admin: get policy by id
   app.get('/api/admin/policies/:id', async (req, res) => {
+    if (!ensureAdminUser(res)) {
+      return;
+    }
+
     try {
       const policy = await storage.getPolicy(req.params.id);
       if (!policy) {
@@ -2366,6 +2420,37 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error('Error fetching policy:', error);
       res.status(500).json({ message: 'Failed to fetch policy' });
+    }
+  });
+
+  app.get('/api/admin/policies/:id/payment-profiles', async (req, res) => {
+    if (!ensureAdminUser(res)) {
+      return;
+    }
+
+    try {
+      const paymentProfiles = await storage.getPaymentProfilesForPolicy(req.params.id);
+      res.json({
+        data: { paymentProfiles },
+        message: 'Payment profiles retrieved successfully',
+      });
+    } catch (error) {
+      console.error('Error fetching payment profiles for policy:', error);
+      res.status(500).json({ message: 'Failed to load payment profiles' });
+    }
+  });
+
+  app.get('/api/admin/policies/:id/charges', async (req, res) => {
+    if (!ensureAdminUser(res)) {
+      return;
+    }
+
+    try {
+      const charges = await storage.listPolicyCharges(req.params.id);
+      res.json({ data: { charges }, message: 'Charges retrieved successfully' });
+    } catch (error) {
+      console.error('Error fetching policy charges:', error);
+      res.status(500).json({ message: 'Failed to load charges' });
     }
   });
 


### PR DESCRIPTION
## Summary
- redesign the customer portal payment page with richer credit card fields, a card preview, and a recent charges table sourced from the new payment charge API
- extend the data model with card metadata and a policy_charges table, adding supporting server routes for customers and admins to view payment info and charge history
- surface stored payment profiles and charge activity on the admin policy detail page for quick review by staff

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd518e58448330a2e316c66ef54028