### PR TITLE
Ensure customer payment profile card fields exist

### DIFF
--- a/migrations/0007_ensure_customer_payment_profile_card_fields.sql
+++ b/migrations/0007_ensure_customer_payment_profile_card_fields.sql
@@ -1,0 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE customer_payment_profiles
+  ADD COLUMN IF NOT EXISTS card_brand varchar(40),
+  ADD COLUMN IF NOT EXISTS card_last_four varchar(4),
+  ADD COLUMN IF NOT EXISTS card_expiry_month integer,
+  ADD COLUMN IF NOT EXISTS card_expiry_year integer,
+  ADD COLUMN IF NOT EXISTS billing_zip varchar(16);


### PR DESCRIPTION
## Summary
- add a migration to ensure payment profile card detail columns exist even if an earlier migration failed
- create the pgcrypto extension when running the migration so gen_random_uuid is always available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd620c79048330bac0dcc3778c1c5e