### PR TITLE
Add fallback policy columns migration

### DIFF
--- a/migrations/0008_align_policy_columns.sql
+++ b/migrations/0008_align_policy_columns.sql
@@ -1,0 +1,10 @@
+ALTER TABLE policies
+  ADD COLUMN IF NOT EXISTS package varchar,
+  ADD COLUMN IF NOT EXISTS expiration_miles integer,
+  ADD COLUMN IF NOT EXISTS expiration_date timestamp,
+  ADD COLUMN IF NOT EXISTS deductible integer,
+  ADD COLUMN IF NOT EXISTS total_premium integer,
+  ADD COLUMN IF NOT EXISTS down_payment integer,
+  ADD COLUMN IF NOT EXISTS policy_start_date timestamp,
+  ADD COLUMN IF NOT EXISTS monthly_payment integer,
+  ADD COLUMN IF NOT EXISTS total_payments integer;


### PR DESCRIPTION
## Summary
- add a defensive migration that backfills optional policy columns when missing to avoid admin policy listing failures

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd70b49c2c833083e7d5db99def31b