### PR TITLE
Fix admin policies loading flow and ensure updated layout renders

### DIFF
--- a/client/src/pages/admin/policies.tsx
+++ b/client/src/pages/admin/policies.tsx
@@ -121,6 +121,11 @@ const getCoverageSummary = (policy: any) => {
 export default function AdminPolicies() {
   const { authenticated, checking, markAuthenticated, markLoggedOut } = useAdminAuth();
   const [, navigate] = useLocation();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [packageFilter, setPackageFilter] = useState<string>('all');
+  const [coverageFilter, setCoverageFilter] = useState<CoverageFilter>('all');
+  const [sortField, setSortField] = useState<string>('createdAt');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const queriesEnabled = authenticated && !checking;
   const { data, isLoading } = useQuery({
     queryKey: ['/api/admin/policies'],
@@ -137,33 +142,10 @@ export default function AdminPolicies() {
     enabled: queriesEnabled,
   });
 
-  if (checking) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
-
-  if (!authenticated) {
-    return <AdminLogin onSuccess={markAuthenticated} />;
-  }
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
-
-  const policies = data?.data || [];
-
-  const [searchTerm, setSearchTerm] = useState("");
-  const [packageFilter, setPackageFilter] = useState<string>('all');
-  const [coverageFilter, setCoverageFilter] = useState<CoverageFilter>('all');
-  const [sortField, setSortField] = useState<string>('createdAt');
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const policies = useMemo(() => {
+    const payload = data?.data;
+    return Array.isArray(payload) ? payload : [];
+  }, [data]);
 
   const packageOptions = useMemo(() => {
     const unique = new Set<string>();
@@ -317,6 +299,26 @@ export default function AdminPolicies() {
     { value: 'expired', label: 'Expired' },
     { value: 'unknown', label: 'Unknown' },
   ];
+
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={markAuthenticated} />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-slate-100 pb-16">


### PR DESCRIPTION
## Summary
- ensure the admin policies page registers all hooks before any early returns so the layout renders reliably
- guard the policies collection from non-array responses while keeping the roster and filters intact
- retain the refreshed policy management layout with loading, login, and spinner states

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ced4a9b03483309aee26d318a9983c