### PR TITLE
Improve policy management experience

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -418,6 +418,24 @@ export class DatabaseStorage implements IStorage {
     return policy;
   }
 
+  async updatePolicyById(id: string, updates: Partial<InsertPolicy>): Promise<Policy | undefined> {
+    const sanitized = Object.fromEntries(
+      Object.entries(updates).filter(([, value]) => value !== undefined),
+    ) as Partial<InsertPolicy>;
+
+    if (Object.keys(sanitized).length === 0) {
+      const [existing] = await db.select().from(policies).where(eq(policies.id, id));
+      return existing;
+    }
+
+    const [policy] = await db
+      .update(policies)
+      .set(sanitized)
+      .where(eq(policies.id, id))
+      .returning();
+    return policy;
+  }
+
   async updatePolicy(leadId: string, updates: Partial<InsertPolicy>): Promise<Policy> {
     const existing = await this.getPolicyByLeadId(leadId);
     if (existing) {


### PR DESCRIPTION
## Summary
- refresh the admin policy email composer with branded previews, a plain-text editor, and an advanced HTML toggle so templates are easy to read and reuse
- surface policy payment updates, full masked card numbers, and an edit dialog so admins can adjust core policy fields
- reorganize document requests into a collapsible snapshot with aggregate customer uploads for quick status reviews

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cedd542d1c8330b1af324f0d9f0bab