### PR TITLE
Ensure payment profile columns exist and fix __dirname usage

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,6 +27,7 @@ import {
 } from "@shared/schema";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { calculateQuote } from "../client/src/lib/pricing";
 import { verifyPassword, hashPassword } from "./password";
 
@@ -132,6 +133,8 @@ const portalContractsBaseUrl = trimmedPortalBaseUrl
   : `${defaultPortalBaseUrl}/portal/contracts`;
 
 const MAX_CONTRACT_FILE_BYTES = 5 * 1024 * 1024;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const placeholderContractPath = path.join(__dirname, 'assets', 'placeholder-contract.pdf');
 let placeholderContractBase64: string | null = null;
@@ -942,6 +945,7 @@ const buildQuoteEmail = ({
 
 export async function registerRoutes(app: Express): Promise<Server> {
   await storage.ensureNumericIdSequences();
+  await storage.ensureCustomerPaymentProfileCardFields();
   await storage.ensureDefaultAdminUser();
   await storage.ensureDefaultEmailTemplates();
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -223,6 +223,7 @@ export interface IStorage {
   ensureNumericIdSequences(): Promise<void>;
   ensureDefaultAdminUser(): Promise<void>;
   ensureDefaultEmailTemplates(): Promise<void>;
+  ensureCustomerPaymentProfileCardFields(): Promise<void>;
 
   // Customer account operations
   getCustomerAccount(id: string): Promise<CustomerAccount | undefined>;
@@ -682,6 +683,17 @@ export class DatabaseStorage implements IStorage {
           9999999
         )
       );
+    `);
+  }
+
+  async ensureCustomerPaymentProfileCardFields(): Promise<void> {
+    await db.execute(sql`
+      ALTER TABLE customer_payment_profiles
+        ADD COLUMN IF NOT EXISTS card_brand varchar(40),
+        ADD COLUMN IF NOT EXISTS card_last_four varchar(4),
+        ADD COLUMN IF NOT EXISTS card_expiry_month integer,
+        ADD COLUMN IF NOT EXISTS card_expiry_year integer,
+        ADD COLUMN IF NOT EXISTS billing_zip varchar(16);
     `);
   }
 


### PR DESCRIPTION
## Summary
- ensure customer payment profile card detail columns exist at startup so queries succeed on older databases
- derive __dirname from import.meta.url in the routes module to support ESM builds
- invoke the new ensure helper during route registration to run the safety migration automatically

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cef3da4a0883308f684f106d653836