### PR TITLE
Allow lead lookup by zero-padded numeric ids

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -75,8 +75,11 @@ const resolveLeadIdCandidates = (value: string | null | undefined): string[] => 
   candidates.add(trimmed);
 
   const digitsOnly = trimmed.replace(/\D/g, '');
-  if (digitsOnly.length === 8) {
+  if (digitsOnly.length > 0) {
     candidates.add(digitsOnly);
+    if (digitsOnly.length < 8) {
+      candidates.add(digitsOnly.padStart(8, '0'));
+    }
   }
 
   return Array.from(candidates);


### PR DESCRIPTION
## Summary
- expand lead id candidate resolution to consider any numeric digits and zero-padded variants when looking up a lead

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf195f65208330a405ccc5fa8dedbb