### PR TITLE
Fix quick template button contrast

### DIFF
--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -1190,7 +1190,7 @@ export default function AdminPolicyDetail() {
                           key={template.id}
                           variant="secondary"
                           size="sm"
-                          className="gap-2 rounded-full border border-slate-200 bg-white px-4"
+                          className="gap-2 rounded-full border border-slate-200 bg-white px-4 text-slate-700 hover:bg-slate-100 hover:text-slate-900"
                           onClick={() => handleOpenEmailDialog(template.id)}
                         >
                           <Sparkles className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- adjust quick template buttons in the policy email tools so their text renders in a dark color on the white background
- add a subtle hover state to keep the buttons legible when admins review template options

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf24a7814c8330b5b9b40777692f19