### PR TITLE
Fix visibility of quick template buttons

### DIFF
--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -1188,9 +1188,9 @@ export default function AdminPolicyDetail() {
                       {defaultTemplates.map(template => (
                         <Button
                           key={template.id}
-                          variant="secondary"
+                          variant="outline"
                           size="sm"
-                          className="gap-2 rounded-full border border-slate-200 bg-white px-4 text-slate-700 hover:bg-slate-100 hover:text-slate-900"
+                          className="gap-2 rounded-full border-slate-200 bg-white px-4 text-slate-700 hover:border-primary/50 hover:bg-primary/10 hover:text-primary"
                           onClick={() => handleOpenEmailDialog(template.id)}
                         >
                           <Sparkles className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- switch quick template buttons to the outline button variant so text inherits dark styling
- add hover treatments that keep the pills readable while still feeling interactive

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf25c82df48330b7f76b09d86b6fef