### PR TITLE
Fix deductible conversion to use whole dollars

### DIFF
--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -67,6 +67,29 @@ const parseCurrencyInput = (value: string): number | null => {
   return Math.round(numeric * 100);
 };
 
+const formatDollarInput = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (Number.isNaN(numeric)) {
+    return '';
+  }
+  return numeric.toFixed(2);
+};
+
+const parseDollarInput = (value: string): number | null => {
+  const normalized = value.replace(/[$,]/g, '').trim();
+  if (!normalized) {
+    return null;
+  }
+  const numeric = Number.parseFloat(normalized);
+  if (Number.isNaN(numeric)) {
+    return null;
+  }
+  return Math.round(numeric);
+};
+
 export default function AdminLeadDetail() {
   const { id } = useParams();
   const { toast } = useToast();
@@ -272,7 +295,6 @@ export default function AdminLeadDetail() {
     }
 
     const currencyFields: (keyof PolicyFormState)[] = [
-      'deductible',
       'totalPremium',
       'downPayment',
       'monthlyPayment',
@@ -284,6 +306,11 @@ export default function AdminLeadDetail() {
       if (cents !== null) {
         payload[field] = cents;
       }
+    }
+
+    const deductibleDollars = parseDollarInput(form.deductible);
+    if (deductibleDollars !== null) {
+      payload.deductible = deductibleDollars;
     }
 
     return payload;
@@ -391,7 +418,7 @@ export default function AdminLeadDetail() {
         package: p.package || '',
         expirationMiles: p.expirationMiles?.toString() || '',
         expirationDate: p.expirationDate ? p.expirationDate.slice(0, 10) : '',
-        deductible: formatCurrencyInput(p.deductible),
+        deductible: formatDollarInput(p.deductible),
         totalPremium: formatCurrencyInput(p.totalPremium),
         downPayment: formatCurrencyInput(p.downPayment),
         policyStartDate: p.policyStartDate ? p.policyStartDate.slice(0, 10) : '',

--- a/client/src/pages/admin/policies.tsx
+++ b/client/src/pages/admin/policies.tsx
@@ -25,6 +25,17 @@ const formatCurrency = (value: number | null | undefined) => {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(numeric / 100);
 };
 
+const formatDeductible = (value: number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) {
+    return '—';
+  }
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(numeric);
+};
+
 const formatDate = (value: string | null | undefined) =>
   value
     ? new Date(value).toLocaleString('en-US', {
@@ -528,7 +539,7 @@ export default function AdminPolicies() {
                             <div className="flex flex-col gap-1">
                               <span className="font-mono text-xs uppercase tracking-wide text-slate-400">{policy.id}</span>
                               <span className="font-medium text-slate-900">{policy.package || 'Package TBD'}</span>
-                              <span className="text-xs text-slate-500">Deductible · {formatCurrency(policy.deductible)}</span>
+                              <span className="text-xs text-slate-500">Deductible · {formatDeductible(policy.deductible)}</span>
                             </div>
                           </TableCell>
                           <TableCell className="px-4 py-3 align-top text-slate-700 whitespace-normal break-words">

--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -77,6 +77,29 @@ const formatCurrencyFromCents = (value: number | null | undefined): string => {
   return formatCurrency(numeric / 100);
 };
 
+const formatDollarInput = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (Number.isNaN(numeric)) {
+    return "";
+  }
+  return numeric.toFixed(2);
+};
+
+const parseDollarInput = (value: string): number | null => {
+  const normalized = value.replace(/[$,]/g, "").trim();
+  if (!normalized) {
+    return null;
+  }
+  const numeric = Number.parseFloat(normalized);
+  if (Number.isNaN(numeric)) {
+    return null;
+  }
+  return Math.round(numeric);
+};
+
 const formatChargeAmount = (value: number | null | undefined): string => {
   if (value === null || value === undefined) return "—";
   const numeric = typeof value === "number" ? value : Number(value);
@@ -212,7 +235,7 @@ const createPolicyFormState = (policy: any) => ({
     policy?.expirationMiles != null && !Number.isNaN(Number(policy.expirationMiles))
       ? String(policy.expirationMiles)
       : "",
-  deductible: formatCurrencyInput(policy?.deductible),
+  deductible: formatDollarInput(policy?.deductible),
   totalPremium: formatCurrencyInput(policy?.totalPremium),
   downPayment: formatCurrencyInput(policy?.downPayment),
   monthlyPayment: formatCurrencyInput(policy?.monthlyPayment),
@@ -363,7 +386,7 @@ const buildDefaultEmailTemplates = (policy: any): EmailTemplateRecord[] => {
     { label: "Effective Date", value: formatDate(policy?.policyStartDate) },
     { label: "Expiration Date", value: formatDate(policy?.expirationDate) },
     { label: "Expiration Miles", value: policy?.expirationMiles != null ? String(policy.expirationMiles) : "N/A" },
-    { label: "Deductible", value: formatCurrencyFromCents(policy?.deductible) },
+    { label: "Deductible", value: formatCurrency(policy?.deductible) },
     { label: "Total Premium", value: formatCurrencyFromCents(policy?.totalPremium) },
   ];
 
@@ -640,7 +663,7 @@ export default function AdminPolicyDetail() {
   const monthlyPaymentDisplay = formatCurrencyFromCents(policy?.monthlyPayment);
   const totalPremiumDisplay = formatCurrencyFromCents(policy?.totalPremium);
   const downPaymentDisplay = formatCurrencyFromCents(policy?.downPayment);
-  const deductibleDisplay = formatCurrencyFromCents(policy?.deductible);
+  const deductibleDisplay = formatCurrency(policy?.deductible);
   const coverageStartDisplay = formatDate(policy?.policyStartDate);
   const coverageEndDisplay = formatDate(policy?.expirationDate);
   const expirationMilesDisplay =
@@ -855,7 +878,7 @@ export default function AdminPolicyDetail() {
         policyForm.expirationMiles.trim() && !Number.isNaN(Number(policyForm.expirationMiles))
           ? Number(policyForm.expirationMiles)
           : null,
-      deductible: parseCurrencyInput(policyForm.deductible),
+      deductible: parseDollarInput(policyForm.deductible),
       totalPremium: parseCurrencyInput(policyForm.totalPremium),
       downPayment: parseCurrencyInput(policyForm.downPayment),
       monthlyPayment: parseCurrencyInput(policyForm.monthlyPayment),

--- a/client/src/pages/portal/overview.tsx
+++ b/client/src/pages/portal/overview.tsx
@@ -68,6 +68,11 @@ function formatFromCents(value: number | null | undefined): string {
   return currencyFormatter.format(value / 100);
 }
 
+function formatDeductible(value: number | null | undefined): string {
+  if (value == null) return "On file";
+  return currencyFormatter.format(value);
+}
+
 function computeMonthlyTotal(policies: CustomerPolicy[]): number {
   return policies.reduce((total, policy) => total + (policy.monthlyPayment ?? 0), 0);
 }
@@ -284,7 +289,7 @@ export default function CustomerPortalOverview({ session }: Props) {
                     </div>
                     <div>
                       <p className="font-medium text-slate-700">Deductible</p>
-                      <p>{formatFromCents(policy.deductible)}</p>
+                      <p>{formatDeductible(policy.deductible)}</p>
                     </div>
                     <div>
                       <p className="font-medium text-slate-700">Monthly payment</p>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1482,7 +1482,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     if (quote) {
       policyData.package = quote.plan;
       if (quote.deductible != null) {
-        policyData.deductible = quote.deductible * 100;
+        policyData.deductible = quote.deductible;
       }
       policyData.totalPremium = quote.priceTotal;
       policyData.monthlyPayment = quote.priceMonthly;


### PR DESCRIPTION
## Summary
- stop multiplying quote deductibles by 100 when creating policies so we persist whole-dollar amounts
- update admin policy management to format and edit deductibles as whole-dollar values
- adjust admin list and customer portal views to display policy deductibles without extra cent conversion

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf26e8a7288330a788ceae2fd2cc78