### PR TITLE
Fix admin dashboard navigation and clean up quick links

### DIFF
--- a/client/src/components/admin-nav.tsx
+++ b/client/src/components/admin-nav.tsx
@@ -16,7 +16,7 @@ function handleLogout() {
 }
 
 const navItems = [
-  { href: "/admin/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
   { href: "/admin/leads", label: "Leads", icon: Users },
   { href: "/admin/policies", label: "Policies", icon: ShieldCheck },
   { href: "/admin/claims", label: "Claims", icon: ClipboardCheck },
@@ -33,7 +33,7 @@ export default function AdminNav() {
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-8">
           <Link
-            href="/admin/dashboard"
+            href="/admin"
             className="hidden text-lg font-semibold tracking-tight text-slate-900 transition hover:text-primary sm:block"
           >
             BHAutoProtect Admin

--- a/client/src/pages/admin/leads.tsx
+++ b/client/src/pages/admin/leads.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
-import { Search, Filter, ArrowUpDown, LayoutList, RefreshCw } from "lucide-react";
+import { Search, Filter, ArrowUpDown, LayoutList } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { useToast } from "@/hooks/use-toast";
 import AdminNav from "@/components/admin-nav";
@@ -297,17 +297,6 @@ export default function AdminLeads() {
             >
               <LayoutList className="h-4 w-4" />
               {hideDuplicates ? 'Show duplicates' : 'Hide duplicates'}
-            </Button>
-            <Button variant="outline" asChild>
-              <Link href="/admin" className="flex items-center gap-2">
-                <RefreshCw className="h-4 w-4" />
-                Dashboard
-              </Link>
-            </Button>
-            <Button variant="outline" asChild>
-              <Link href="/" className="flex items-center gap-2">
-                Public site
-              </Link>
             </Button>
             <Button asChild>
               <Link href="/admin/leads/new">Add lead</Link>

--- a/client/src/pages/admin/policies.tsx
+++ b/client/src/pages/admin/policies.tsx
@@ -350,18 +350,7 @@ export default function AdminPolicies() {
               Review customer policies, confirm coverage details, and jump into the full record with a single click.
             </p>
           </div>
-          <div className="flex flex-wrap gap-2">
-            <Button variant="outline" asChild>
-              <Link href="/admin" className="flex items-center gap-2">
-                Dashboard
-              </Link>
-            </Button>
-            <Button variant="outline" asChild>
-              <Link href="/" className="flex items-center gap-2">
-                Public site
-              </Link>
-            </Button>
-          </div>
+          <div className="flex flex-wrap gap-2" />
         </div>
 
         <Card className="border border-slate-200 bg-white shadow-sm">


### PR DESCRIPTION
## Summary
- point the admin dashboard navigation link to the /admin route to avoid 404s
- remove redundant dashboard and public site buttons from the admin leads and policies quick actions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf2fd91a908330855bc3053853f4f0