### PR TITLE
Redesign quote modal as single page form

### DIFF
--- a/client/src/components/quote-modal.tsx
+++ b/client/src/components/quote-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import { useLocation } from "wouter";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -6,10 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Progress } from "@/components/ui/progress";
 import { useToast } from "@/hooks/use-toast";
-import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { US_STATES } from "@/lib/constants";
@@ -37,10 +34,6 @@ interface QuoteData {
     zip: string;
     state: string;
   };
-  coverage: {
-    payment: string;
-    addOns: string[];
-  };
   consent: {
     tcpa: boolean;
     terms: boolean;
@@ -48,28 +41,23 @@ interface QuoteData {
 }
 
 export default function QuoteModal({ isOpen, onClose }: QuoteModalProps) {
-  const [currentStep, setCurrentStep] = useState(1);
   const [quoteData, setQuoteData] = useState<QuoteData>({
     vehicle: {
-      year: '',
-      make: '',
-      model: '',
-      trim: '',
-      odometer: '',
-      vin: '',
-      usage: 'personal',
+      year: "",
+      make: "",
+      model: "",
+      trim: "",
+      odometer: "",
+      vin: "",
+      usage: "personal",
     },
     owner: {
-      firstName: '',
-      lastName: '',
-      email: '',
-      phone: '',
-      zip: '',
-      state: '',
-    },
-    coverage: {
-      payment: 'monthly',
-      addOns: [],
+      firstName: "",
+      lastName: "",
+      email: "",
+      phone: "",
+      zip: "",
+      state: "",
     },
     consent: {
       tcpa: false,
@@ -91,7 +79,7 @@ export default function QuoteModal({ isOpen, onClose }: QuoteModalProps) {
           zip: data.owner.zip,
           state: data.owner.state,
           consentTCPA: data.consent.tcpa,
-          source: 'web',
+          source: "web",
         },
         vehicle: {
           year: parseInt(data.vehicle.year),
@@ -119,70 +107,29 @@ export default function QuoteModal({ isOpen, onClose }: QuoteModalProps) {
   });
 
   const resetForm = () => {
-    setCurrentStep(1);
     setQuoteData({
       vehicle: {
-        year: '',
-        make: '',
-        model: '',
-        trim: '',
-        odometer: '',
-        vin: '',
-        usage: 'personal',
+        year: "",
+        make: "",
+        model: "",
+        trim: "",
+        odometer: "",
+        vin: "",
+        usage: "personal",
       },
-    owner: {
-      firstName: '',
-      lastName: '',
-      email: '',
-      phone: '',
-      zip: '',
-      state: '',
-    },
-    coverage: {
-      payment: 'monthly',
-      addOns: [],
-    },
-    consent: {
-      tcpa: false,
-      terms: false,
-    },
-  });
-  };
-
-  const nextStep = () => {
-    if (currentStep === 1) {
-      const { year, make, model, odometer } = quoteData.vehicle;
-      if (!year || !make || !model || !odometer) {
-        toast({
-          title: "Missing Vehicle Information",
-          description: "Please complete all required vehicle fields.",
-          variant: "destructive",
-        });
-        return;
-      }
-    }
-
-    if (currentStep === 2) {
-      const { firstName, lastName, email, phone, zip, state } = quoteData.owner;
-      if (!firstName || !lastName || !email || !phone || !zip || !state) {
-        toast({
-          title: "Missing Contact Information",
-          description: "Please complete all required contact fields.",
-          variant: "destructive",
-        });
-        return;
-      }
-    }
-
-    if (currentStep < 3) {
-      setCurrentStep(currentStep + 1);
-    }
-  };
-
-  const previousStep = () => {
-    if (currentStep > 1) {
-      setCurrentStep(currentStep - 1);
-    }
+      owner: {
+        firstName: "",
+        lastName: "",
+        email: "",
+        phone: "",
+        zip: "",
+        state: "",
+      },
+      consent: {
+        tcpa: false,
+        terms: false,
+      },
+    });
   };
 
   const submitQuote = () => {
@@ -194,320 +141,265 @@ export default function QuoteModal({ isOpen, onClose }: QuoteModalProps) {
       });
       return;
     }
-    
+
     submitQuoteMutation.mutate(quoteData);
   };
 
   const handleVehicleChange = (field: string, value: string) => {
-    setQuoteData(prev => ({
+    setQuoteData((prev) => ({
       ...prev,
-      vehicle: { ...prev.vehicle, [field]: value }
+      vehicle: { ...prev.vehicle, [field]: value },
     }));
   };
 
   const handleOwnerChange = (field: string, value: string) => {
-    setQuoteData(prev => ({
+    setQuoteData((prev) => ({
       ...prev,
-      owner: { ...prev.owner, [field]: value }
-    }));
-  };
-
-  const handleCoverageChange = (field: string, value: string) => {
-    setQuoteData(prev => ({
-      ...prev,
-      coverage: { ...prev.coverage, [field]: value }
+      owner: { ...prev.owner, [field]: value },
     }));
   };
 
   const handleConsentChange = (field: string, value: boolean) => {
-    setQuoteData(prev => ({
+    setQuoteData((prev) => ({
       ...prev,
-      consent: { ...prev.consent, [field]: value }
+      consent: { ...prev.consent, [field]: value },
     }));
   };
 
-  const progress = (currentStep / 3) * 100;
+  const validateRequiredFields = () => {
+    const { year, make, model, odometer } = quoteData.vehicle;
+    const { firstName, lastName, email, phone, zip, state } = quoteData.owner;
+
+    if (!year || !make || !model || !odometer) {
+      toast({
+        title: "Missing Vehicle Information",
+        description: "Please complete all required vehicle fields.",
+        variant: "destructive",
+      });
+      return false;
+    }
+
+    if (!firstName || !lastName || !email || !phone || !zip || !state) {
+      toast({
+        title: "Missing Contact Information",
+        description: "Please complete all required contact fields.",
+        variant: "destructive",
+      });
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validateRequiredFields()) {
+      return;
+    }
+
+    submitQuote();
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Get Your Free Quote</DialogTitle>
-          
-          {/* Progress Bar */}
-          <div className="mt-6">
-            <div className="flex justify-between items-center mb-2">
-              <span className="text-sm font-medium text-gray-500">Step {currentStep} of 3</span>
-              <span className="text-sm font-medium text-gray-500">{Math.round(progress)}% Complete</span>
-            </div>
-            <Progress value={progress} className="h-2" />
-          </div>
-          
-          {/* Step Indicators */}
-          <div className="flex justify-center mt-6 space-x-8">
-            <div className="flex items-center">
-              <div className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-sm font-semibold ${
-                currentStep >= 1 ? 'bg-primary text-white border-primary' : 'border-gray-300 text-gray-500'
-              }`}>
-                1
-              </div>
-              <span className="ml-2 text-sm font-medium">Vehicle</span>
-            </div>
-            <div className="flex items-center">
-              <div className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-sm font-semibold ${
-                currentStep >= 2 ? 'bg-primary text-white border-primary' : 'border-gray-300 text-gray-500'
-              }`}>
-                2
-              </div>
-              <span className="ml-2 text-sm font-medium">Owner</span>
-            </div>
-            <div className="flex items-center">
-              <div className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-sm font-semibold ${
-                currentStep >= 3 ? 'bg-primary text-white border-primary' : 'border-gray-300 text-gray-500'
-              }`}>
-                3
-              </div>
-              <span className="ml-2 text-sm font-medium">Coverage</span>
-            </div>
-          </div>
-        </DialogHeader>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <form onSubmit={handleSubmit} className="space-y-8">
+          <DialogHeader className="space-y-3">
+            <DialogTitle className="text-3xl font-bold">Get Your Free Quote</DialogTitle>
+            <p className="text-gray-500">
+              Provide a few quick details and we&apos;ll prepare a personalized quote for your vehicle warranty coverage.
+            </p>
+          </DialogHeader>
 
-        <div className="py-6">
-          {/* Step 1: Vehicle Information */}
-          {currentStep === 1 && (
+          <section className="bg-gray-50 rounded-2xl p-6 border border-gray-100">
+            <div className="flex items-start justify-between mb-6">
+              <div>
+                <h3 className="text-xl font-semibold text-gray-900">Vehicle information</h3>
+                <p className="text-sm text-gray-500">Tell us about the car or truck you&apos;d like to protect.</p>
+              </div>
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="year">Year</Label>
+                <Input
+                  id="year"
+                  type="number"
+                  placeholder="e.g., 2020"
+                  value={quoteData.vehicle.year}
+                  onChange={(e) => handleVehicleChange("year", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="make">Make</Label>
+                <Input
+                  id="make"
+                  placeholder="e.g., Toyota"
+                  value={quoteData.vehicle.make}
+                  onChange={(e) => handleVehicleChange("make", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="model">Model</Label>
+                <Input
+                  id="model"
+                  placeholder="e.g., Camry"
+                  value={quoteData.vehicle.model}
+                  onChange={(e) => handleVehicleChange("model", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="trim">Trim (Optional)</Label>
+                <Input
+                  id="trim"
+                  placeholder="e.g., XLE"
+                  value={quoteData.vehicle.trim}
+                  onChange={(e) => handleVehicleChange("trim", e.target.value)}
+                />
+              </div>
+              <div className="md:col-span-2">
+                <Label htmlFor="odometer">Odometer reading</Label>
+                <Input
+                  id="odometer"
+                  type="number"
+                  placeholder="e.g., 45,000"
+                  value={quoteData.vehicle.odometer}
+                  onChange={(e) => handleVehicleChange("odometer", e.target.value)}
+                  required
+                />
+              </div>
+              <div className="md:col-span-2">
+                <Label htmlFor="vin">VIN (optional)</Label>
+                <Input
+                  id="vin"
+                  type="text"
+                  placeholder="17-character VIN"
+                  value={quoteData.vehicle.vin}
+                  onChange={(e) => handleVehicleChange("vin", e.target.value)}
+                />
+                <p className="text-sm text-gray-500 mt-1">Providing your VIN helps us give you a more accurate quote.</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="bg-gray-50 rounded-2xl p-6 border border-gray-100">
+            <div className="flex items-start justify-between mb-6">
+              <div>
+                <h3 className="text-xl font-semibold text-gray-900">Contact details</h3>
+                <p className="text-sm text-gray-500">We&apos;ll deliver your quote and follow up with any questions.</p>
+              </div>
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="firstName">First name</Label>
+                <Input
+                  id="firstName"
+                  value={quoteData.owner.firstName}
+                  onChange={(e) => handleOwnerChange("firstName", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="lastName">Last name</Label>
+                <Input
+                  id="lastName"
+                  value={quoteData.owner.lastName}
+                  onChange={(e) => handleOwnerChange("lastName", e.target.value)}
+                  required
+                />
+              </div>
+              <div className="md:col-span-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={quoteData.owner.email}
+                  onChange={(e) => handleOwnerChange("email", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="phone">Phone</Label>
+                <Input
+                  id="phone"
+                  type="tel"
+                  value={quoteData.owner.phone}
+                  onChange={(e) => handleOwnerChange("phone", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="zip">ZIP code</Label>
+                <Input
+                  id="zip"
+                  value={quoteData.owner.zip}
+                  onChange={(e) => handleOwnerChange("zip", e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="state">State</Label>
+                <Select value={quoteData.owner.state} onValueChange={(value) => handleOwnerChange("state", value)} required>
+                  <SelectTrigger id="state">
+                    <SelectValue placeholder="Select state" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {US_STATES.map((state) => (
+                      <SelectItem key={state.value} value={state.value}>
+                        {state.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </section>
+
+          <section className="bg-gray-50 rounded-2xl p-6 border border-gray-100 space-y-4">
             <div>
-              <h3 className="text-xl font-semibold mb-6">Tell us about your vehicle</h3>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="year">Year</Label>
-                  <Input
-                    id="year"
-                    type="number"
-                    placeholder="e.g., 2020"
-                    value={quoteData.vehicle.year}
-                    onChange={(e) => handleVehicleChange('year', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="make">Make</Label>
-                  <Input
-                    id="make"
-                    placeholder="e.g., Toyota"
-                    value={quoteData.vehicle.make}
-                    onChange={(e) => handleVehicleChange('make', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="model">Model</Label>
-                  <Input
-                    id="model"
-                    placeholder="e.g., Camry"
-                    value={quoteData.vehicle.model}
-                    onChange={(e) => handleVehicleChange('model', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="trim">Trim (Optional)</Label>
-                  <Input
-                    id="trim"
-                    placeholder="e.g., XLE"
-                    value={quoteData.vehicle.trim}
-                    onChange={(e) => handleVehicleChange('trim', e.target.value)}
-                  />
-                </div>
-                <div className="md:col-span-2">
-                  <Label htmlFor="odometer">Odometer Reading</Label>
-                  <Input
-                    type="number"
-                    placeholder="e.g., 45000"
-                    value={quoteData.vehicle.odometer}
-                    onChange={(e) => handleVehicleChange('odometer', e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="md:col-span-2">
-                  <Label htmlFor="vin">VIN (Optional)</Label>
-                  <Input 
-                    type="text" 
-                    placeholder="17-character VIN" 
-                    value={quoteData.vehicle.vin}
-                    onChange={(e) => handleVehicleChange('vin', e.target.value)}
-                  />
-                  <p className="text-sm text-gray-500 mt-1">Providing your VIN helps us give you a more accurate quote</p>
-                </div>
-                <div className="md:col-span-2">
-                  <Label>Usage</Label>
-                  <RadioGroup 
-                    value={quoteData.vehicle.usage} 
-                    onValueChange={(value) => handleVehicleChange('usage', value)}
-                    className="grid grid-cols-2 gap-4 mt-2"
-                  >
-                    <div className="flex items-center space-x-2">
-                      <RadioGroupItem value="personal" id="personal" />
-                      <Label htmlFor="personal">Personal</Label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <RadioGroupItem value="commercial" id="commercial" />
-                      <Label htmlFor="commercial">Commercial</Label>
-                    </div>
-                  </RadioGroup>
-                </div>
+              <h3 className="text-xl font-semibold text-gray-900">Consent &amp; terms</h3>
+              <p className="text-sm text-gray-500">
+                We respect your privacy and will only use your information to share quote details and coverage options.
+              </p>
+            </div>
+            <div className="space-y-3">
+              <div className="flex items-start">
+                <Checkbox
+                  id="tcpa"
+                  checked={quoteData.consent.tcpa}
+                  onCheckedChange={(checked) => handleConsentChange("tcpa", !!checked)}
+                  className="mt-1"
+                />
+                <Label htmlFor="tcpa" className="ml-3 text-sm">
+                  By clicking Continue, you agree to be contacted by phone, SMS, or email regarding your auto warranty options. Consent is not a condition of purchase. Msg &amp; data rates may apply.
+                </Label>
+              </div>
+              <div className="flex items-start">
+                <Checkbox
+                  id="terms"
+                  checked={quoteData.consent.terms}
+                  onCheckedChange={(checked) => handleConsentChange("terms", !!checked)}
+                  className="mt-1"
+                />
+                <Label htmlFor="terms" className="ml-3 text-sm">
+                  I agree to the <a href="/legal/privacy" className="text-primary hover:underline">Privacy Policy</a> and <a href="/legal/terms" className="text-primary hover:underline">Terms of Service</a>.
+                </Label>
               </div>
             </div>
-          )}
+          </section>
 
-          {/* Step 2: Owner Information */}
-          {currentStep === 2 && (
-            <div>
-              <h3 className="text-xl font-semibold mb-6">Contact Information</h3>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="firstName">First Name</Label>
-                  <Input
-                    value={quoteData.owner.firstName}
-                    onChange={(e) => handleOwnerChange('firstName', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="lastName">Last Name</Label>
-                  <Input
-                    value={quoteData.owner.lastName}
-                    onChange={(e) => handleOwnerChange('lastName', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    type="email"
-                    value={quoteData.owner.email}
-                    onChange={(e) => handleOwnerChange('email', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="phone">Phone</Label>
-                  <Input
-                    type="tel"
-                    value={quoteData.owner.phone}
-                    onChange={(e) => handleOwnerChange('phone', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="zip">ZIP Code</Label>
-                  <Input
-                    value={quoteData.owner.zip}
-                    onChange={(e) => handleOwnerChange('zip', e.target.value)}
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="state">State</Label>
-                  <Select value={quoteData.owner.state} onValueChange={(value) => handleOwnerChange('state', value)} required>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select State" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {US_STATES.map((state) => (
-                        <SelectItem key={state.value} value={state.value}>
-                          {state.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Step 3: Coverage Preferences */}
-          {currentStep === 3 && (
-            <div>
-              <h3 className="text-xl font-semibold mb-6">Coverage Preferences</h3>
-              <div className="space-y-6">
-                <div>
-                  <Label className="text-sm font-medium mb-3 block">Payment Preference</Label>
-                  <RadioGroup
-                    value={quoteData.coverage.payment}
-                    onValueChange={(value) => handleCoverageChange('payment', value)}
-                    className="grid grid-cols-2 gap-4"
-                  >
-                    <div className="flex items-center p-3 border rounded-lg cursor-pointer hover:bg-gray-50">
-                      <RadioGroupItem value="monthly" id="monthly" />
-                      <Label htmlFor="monthly" className="ml-2">Monthly Payments</Label>
-                    </div>
-                    <div className="flex items-center p-3 border rounded-lg cursor-pointer hover:bg-gray-50">
-                      <RadioGroupItem value="full" id="full" />
-                      <Label htmlFor="full" className="ml-2">Paid in Full (Save more)</Label>
-                    </div>
-                  </RadioGroup>
-                </div>
-
-                <div className="bg-gray-50 p-4 rounded-lg">
-                  <h4 className="font-semibold mb-3">Consent & Terms</h4>
-                  <div className="space-y-3">
-                    <div className="flex items-start">
-                      <Checkbox
-                        id="tcpa"
-                        checked={quoteData.consent.tcpa}
-                        onCheckedChange={(checked) => handleConsentChange('tcpa', !!checked)}
-                        className="mt-1"
-                      />
-                      <Label htmlFor="tcpa" className="ml-3 text-sm">
-                        By clicking Continue, you agree to be contacted by phone, SMS, or email regarding your auto warranty options. Consent is not a condition of purchase. Msg & data rates may apply.
-                      </Label>
-                    </div>
-                    <div className="flex items-start">
-                      <Checkbox
-                        id="terms"
-                        checked={quoteData.consent.terms}
-                        onCheckedChange={(checked) => handleConsentChange('terms', !!checked)}
-                        className="mt-1"
-                      />
-                      <Label htmlFor="terms" className="ml-3 text-sm">
-                        I agree to the <a href="/legal/privacy" className="text-primary hover:underline">Privacy Policy</a> and <a href="/legal/terms" className="text-primary hover:underline">Terms of Service</a>
-                      </Label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="flex justify-between pt-4 border-t">
-          <Button 
-            variant="outline" 
-            onClick={previousStep} 
-            disabled={currentStep === 1}
-            className={currentStep === 1 ? "invisible" : ""}
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Previous
-          </Button>
-          
-          <div className="flex-1"></div>
-          
-          {currentStep < 3 ? (
-            <Button onClick={nextStep}>
-              Next Step
-              <ArrowRight className="w-4 h-4 ml-2" />
-            </Button>
-          ) : (
-            <Button 
-              onClick={submitQuote} 
+          <div className="flex justify-end pt-2">
+            <Button
+              type="submit"
               disabled={submitQuoteMutation.isPending}
-              className="bg-accent hover:bg-green-600"
+              className="bg-accent hover:bg-green-600 px-8"
             >
-              {submitQuoteMutation.isPending ? "Submitting..." : "Get My Quote"}
+              {submitQuoteMutation.isPending ? "Submitting..." : "Get my quote"}
             </Button>
-          )}
-        </div>
+          </div>
+        </form>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- replace the step-based quote modal with a single scrolling form that groups vehicle, contact, and consent details in dedicated sections
- remove the commercial/personal usage toggle and payment preference radios while keeping required validation and consent handling intact
- keep submission flow unchanged with improved inline copy and contextual guidance

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf301008988330b6527d48cc4c9afa