### PR TITLE
Adjust hero banner positioning

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -186,19 +186,19 @@ export default function Landing() {
                   alt="Modern car dashboard"
                   className="w-full h-full object-cover"
                 />
-                <div className="absolute bottom-6 left-6 right-6 grid gap-4 text-sm text-white">
-                  <div className="flex items-center justify-between rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
-                    <span className="flex items-center gap-2 font-semibold">
-                      <Gauge className="w-4 h-4" /> 24/7 Roadside Assistance
-                    </span>
-                    <span className="text-blue-100">Included</span>
-                  </div>
-                  <div className="flex items-center justify-between rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
-                    <span className="flex items-center gap-2 font-semibold">
-                      <Wrench className="w-4 h-4" /> Repairs Paid Directly
-                    </span>
-                    <span className="text-blue-100">Nationwide</span>
-                  </div>
+              </div>
+              <div className="mt-6 grid gap-4 text-sm text-white">
+                <div className="flex items-center justify-between rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
+                  <span className="flex items-center gap-2 font-semibold">
+                    <Gauge className="w-4 h-4" /> 24/7 Roadside Assistance
+                  </span>
+                  <span className="text-blue-100">Included</span>
+                </div>
+                <div className="flex items-center justify-between rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
+                  <span className="flex items-center gap-2 font-semibold">
+                    <Wrench className="w-4 h-4" /> Repairs Paid Directly
+                  </span>
+                  <span className="text-blue-100">Nationwide</span>
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
## Summary
- reposition the roadside assistance and repair highlight cards to sit below the hero image so the photo remains unobstructed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf32c15ba483309739f6ec375eb907