### PR TITLE
Remove bronze plan and expand policy editing

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -46,7 +46,7 @@ export default function Footer() {
           <div>
             <h4 className="text-lg font-semibold mb-4">Coverage</h4>
             <ul className="space-y-2 text-gray-400">
-              <li><a href="/plans" className="hover:text-white">Bronze Plan</a></li>
+              <li><a href="/plans" className="hover:text-white">Basic Coverage</a></li>
               <li><a href="/plans" className="hover:text-white">Silver Coverage</a></li>
               <li><a href="/plans" className="hover:text-white">Gold Protection</a></li>
               <li><a href="/plans" className="hover:text-white">Add-On Options</a></li>

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -101,10 +101,6 @@ export const COVERAGE_PLANS = {
     name: 'Basic',
     features: CORE_PLAN_FEATURES,
   },
-  bronze: {
-    name: 'Bronze',
-    features: CORE_PLAN_FEATURES,
-  },
   gold: {
     name: 'Gold',
     description: 'Most Comprehensive!',
@@ -152,7 +148,7 @@ export const COVERAGE_PLANS = {
     ],
   },
 } satisfies Record<
-  'basic' | 'bronze' | 'gold' | 'silver',
+  'basic' | 'gold' | 'silver',
   {
     name: string;
     features: readonly string[];

--- a/client/src/lib/pricing.ts
+++ b/client/src/lib/pricing.ts
@@ -6,7 +6,7 @@ export interface VehicleInfo {
 }
 
 export interface CoverageInfo {
-  plan: "basic" | "bronze" | "silver" | "gold";
+  plan: "basic" | "silver" | "gold";
   deductible: number;
 }
 
@@ -40,7 +40,6 @@ export function calculateQuote(
   let basePrice = 0;
   switch (coverage.plan) {
     case "basic":
-    case "bronze":
       basePrice = 60;
       break;
     case "silver":

--- a/client/src/pages/admin/leads/[id].tsx
+++ b/client/src/pages/admin/leads/[id].tsx
@@ -943,7 +943,6 @@ export default function AdminLeadDetail() {
                             </SelectTrigger>
                             <SelectContent>
                               <SelectItem value="basic">Basic</SelectItem>
-                              <SelectItem value="bronze">Bronze</SelectItem>
                               <SelectItem value="silver">Silver</SelectItem>
                               <SelectItem value="gold">Gold</SelectItem>
                             </SelectContent>
@@ -1146,7 +1145,6 @@ export default function AdminLeadDetail() {
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="basic">Basic</SelectItem>
-                          <SelectItem value="bronze">Bronze</SelectItem>
                           <SelectItem value="silver">Silver</SelectItem>
                           <SelectItem value="gold">Gold</SelectItem>
                         </SelectContent>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -469,7 +469,7 @@ export default function Landing() {
               </AccordionTrigger>
               <AccordionContent className="text-gray-600 leading-relaxed">
                 Our extended warranties cover major mechanical breakdowns including engine, transmission, electrical systems, air
-                conditioning, and more. Coverage varies by plan—Bronze covers essential systems, Silver adds steering, suspension,
+                conditioning, and more. Coverage varies by plan—Basic covers essential systems, Silver adds steering, suspension,
                 and high-tech components, and Gold extends coverage to seals, gaskets, and hybrid/EV components.
               </AccordionContent>
             </AccordionItem>

--- a/client/src/pages/legal/terms.tsx
+++ b/client/src/pages/legal/terms.tsx
@@ -59,7 +59,7 @@ export default function TermsPage() {
                   <h3 className="text-lg font-medium text-gray-900 mb-2">Coverage Details</h3>
                   <p>
                     Specific coverage details are outlined in your individual warranty contract. Coverage varies
-                    by plan type (Bronze, Silver, Gold) and includes mechanical breakdown protection for
+                    by plan type (Basic, Silver, Gold) and includes mechanical breakdown protection for
                     covered components as specified in your contract terms.
                   </p>
                 </div>

--- a/client/src/pages/policy/index.tsx
+++ b/client/src/pages/policy/index.tsx
@@ -139,7 +139,7 @@ export default function PolicyOverview() {
           <div>
             <h2 className="text-3xl font-bold text-gray-900">What your policy includes</h2>
             <p className="mt-4 text-gray-600 leading-relaxed">
-              Whether you choose Bronze, Silver, or Gold, every policy is built around the same promise: quick coverage decisions,
+              Whether you choose Basic, Silver, or Gold, every policy is built around the same promise: quick coverage decisions,
               transparent pricing, and real humans who can help at every turn.
             </p>
             <ul className="mt-6 space-y-4">

--- a/migrations/0011_remove_bronze_from_plan_type.sql
+++ b/migrations/0011_remove_bronze_from_plan_type.sql
@@ -1,0 +1,23 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'plan_type'
+  ) THEN
+    UPDATE quotes SET plan = 'basic' WHERE plan = 'bronze';
+
+    IF EXISTS (
+      SELECT 1
+      FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      WHERE t.typname = 'plan_type' AND e.enumlabel = 'bronze'
+    ) THEN
+      ALTER TYPE plan_type RENAME TO plan_type_old;
+      CREATE TYPE plan_type AS ENUM ('basic', 'silver', 'gold');
+      ALTER TABLE quotes ALTER COLUMN plan TYPE plan_type USING plan::text::plan_type;
+      DROP TYPE plan_type_old;
+    END IF;
+  END IF;
+END $$;

--- a/replit.md
+++ b/replit.md
@@ -26,7 +26,7 @@ Preferred communication style: Simple, everyday language.
 - **Normalized Schema**: Comprehensive database schema with proper relationships and foreign keys
 - **Lead Management**: Complete lead lifecycle from initial contact through policy binding
 - **Vehicle Data**: Detailed vehicle information including VIN, odometer, make/model
-- **Quote System**: Multiple plan tiers (Bronze, Silver, Gold)
+- **Quote System**: Multiple plan tiers (Basic, Silver, Gold)
 - **Policy Management**: Full policy lifecycle including payments and documents
 - **Audit Trail**: Comprehensive logging of user actions and data changes
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
 // Enums
-export const planTypeEnum = pgEnum('plan_type', ['basic', 'bronze', 'silver', 'gold']);
+export const planTypeEnum = pgEnum('plan_type', ['basic', 'silver', 'gold']);
 export const quoteStatusEnum = pgEnum('quote_status', ['draft', 'sent', 'accepted', 'rejected']);
 export const claimStatusEnum = pgEnum('claim_status', [
   'new',


### PR DESCRIPTION
## Summary
- remove all bronze plan options in favor of the Basic/Silver/Gold lineup across constants, UI copy, and admin tools
- add a migration and schema updates to drop the bronze enum value and keep policy names capitalized in the admin workspace
- allow administrators to update customer and vehicle data from the policy dialog with matching API support

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf36e8201c8330ac8dcd1b7a7d6349