### PR TITLE
Refine admin claims list and detail experiences

### DIFF
--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -1,15 +1,132 @@
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Link } from "wouter";
+import { Filter, Search, ArrowUpDown, Clock3, AlertTriangle, CheckCircle2 } from "lucide-react";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
 import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 
+type ClaimRecord = {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  message?: string | null;
+  status: ClaimStatus;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  nextEstimate?: string | null;
+  nextPayment?: string | null;
+  year?: string | null;
+  make?: string | null;
+  model?: string | null;
+};
+
+type ClaimStatus =
+  | "new"
+  | "denied"
+  | "awaiting_customer_action"
+  | "awaiting_inspection"
+  | "claim_covered_open"
+  | "claim_covered_closed";
+
+const statusMeta: Record<ClaimStatus, { label: string; description: string; badgeClass: string }> = {
+  new: {
+    label: "New",
+    description: "Recently submitted and awaiting review.",
+    badgeClass: "border-sky-200 bg-sky-50 text-sky-700",
+  },
+  denied: {
+    label: "Denied",
+    description: "Customer has been notified of denial.",
+    badgeClass: "border-rose-200 bg-rose-50 text-rose-700",
+  },
+  awaiting_customer_action: {
+    label: "Awaiting customer",
+    description: "Needs documentation or response from the customer.",
+    badgeClass: "border-amber-200 bg-amber-50 text-amber-700",
+  },
+  awaiting_inspection: {
+    label: "Awaiting inspection",
+    description: "Inspection or diagnostics are in progress.",
+    badgeClass: "border-indigo-200 bg-indigo-50 text-indigo-700",
+  },
+  claim_covered_open: {
+    label: "Covered - open",
+    description: "Approved claim with work still in progress.",
+    badgeClass: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  },
+  claim_covered_closed: {
+    label: "Covered - closed",
+    description: "Work completed and claim fully paid.",
+    badgeClass: "border-slate-200 bg-slate-50 text-slate-600",
+  },
+};
+
+const statusFilters: { value: ClaimStatus | "all"; label: string }[] = [
+  { value: "all", label: "All statuses" },
+  { value: "new", label: statusMeta.new.label },
+  { value: "awaiting_customer_action", label: statusMeta.awaiting_customer_action.label },
+  { value: "awaiting_inspection", label: statusMeta.awaiting_inspection.label },
+  { value: "claim_covered_open", label: statusMeta.claim_covered_open.label },
+  { value: "claim_covered_closed", label: statusMeta.claim_covered_closed.label },
+  { value: "denied", label: statusMeta.denied.label },
+];
+
+const openStatuses: ClaimStatus[] = [
+  "new",
+  "awaiting_customer_action",
+  "awaiting_inspection",
+  "claim_covered_open",
+];
+
+const attentionStatuses: ClaimStatus[] = ["awaiting_customer_action", "awaiting_inspection", "denied"];
+
+const formatDate = (value: string | null | undefined) =>
+  value
+    ? new Date(value).toLocaleString("en-US", {
+        timeZone: "America/New_York",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "—";
+
+const formatDateTime = (value: string | null | undefined) =>
+  value
+    ? new Date(value).toLocaleString("en-US", {
+        timeZone: "America/New_York",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : "—";
+
+const formatName = (claim: ClaimRecord) =>
+  `${claim.firstName ?? ""} ${claim.lastName ?? ""}`.trim() || "Unassigned";
+
+const formatVehicle = (claim: ClaimRecord) => {
+  const details = [claim.year, claim.make, claim.model].filter(Boolean).join(" ");
+  return details || "—";
+};
+
 export default function AdminClaims() {
   const { authenticated, checking, markAuthenticated, markLoggedOut } = useAdminAuth();
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [statusFilter, setStatusFilter] = useState<ClaimStatus | "all">("all");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
   const { data, isLoading } = useQuery({
     queryKey: ['/api/admin/claims'],
@@ -46,61 +163,212 @@ export default function AdminClaims() {
     );
   }
 
-  const claims = data?.data || [];
+  const claims: ClaimRecord[] = data?.data || [];
+
+  const { totalClaims, openClaims, attentionClaims } = useMemo(() => {
+    const total = claims.length;
+    const open = claims.filter((claim) => openStatuses.includes(claim.status)).length;
+    const needsAttention = claims.filter((claim) => attentionStatuses.includes(claim.status)).length;
+    return { totalClaims: total, openClaims: open, attentionClaims: needsAttention };
+  }, [claims]);
+
+  const filteredClaims = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return claims
+      .filter((claim) => {
+        if (statusFilter !== "all" && claim.status !== statusFilter) {
+          return false;
+        }
+
+        if (!normalizedSearch) {
+          return true;
+        }
+
+        const haystack = [
+          claim.firstName,
+          claim.lastName,
+          claim.email,
+          claim.phone,
+          claim.id,
+          claim.message,
+          claim.make,
+          claim.model,
+          claim.year,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+
+        return haystack.includes(normalizedSearch);
+      })
+      .sort((a, b) => {
+        const aDate = a.updatedAt ?? a.createdAt ?? "";
+        const bDate = b.updatedAt ?? b.createdAt ?? "";
+        const aTime = aDate ? new Date(aDate).getTime() : 0;
+        const bTime = bDate ? new Date(bDate).getTime() : 0;
+        return sortOrder === "desc" ? bTime - aTime : aTime - bTime;
+      });
+  }, [claims, searchTerm, statusFilter, sortOrder]);
 
   return (
     <div className="min-h-screen bg-gray-50">
       <AdminNav />
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="mb-4 flex justify-end">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">Claims dashboard</h1>
+            <p className="text-sm text-slate-600">Track active repairs, customer follow-ups, and closed cases in one view.</p>
+          </div>
           <Button asChild>
-            <Link href="/admin/claims/new">Add Claim</Link>
+            <Link href="/admin/claims/new">Add claim</Link>
           </Button>
         </div>
-        <Card>
-          <CardHeader>
-            <CardTitle>Claims</CardTitle>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <Card className="border-slate-200/80">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardDescription>Total claims</CardDescription>
+              <CheckCircle2 className="h-5 w-5 text-primary" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-semibold text-slate-900">{totalClaims}</div>
+              <p className="mt-1 text-xs text-slate-500">Includes every submission regardless of outcome.</p>
+            </CardContent>
+          </Card>
+          <Card className="border-slate-200/80">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardDescription>Open cases</CardDescription>
+              <Clock3 className="h-5 w-5 text-primary" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-semibold text-slate-900">{openClaims}</div>
+              <p className="mt-1 text-xs text-slate-500">Marked as new, awaiting action, inspection, or in-progress repairs.</p>
+            </CardContent>
+          </Card>
+          <Card className="border-slate-200/80">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardDescription>Needs attention</CardDescription>
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-semibold text-slate-900">{attentionClaims}</div>
+              <p className="mt-1 text-xs text-slate-500">Awaiting documents, inspection results, or recently denied.</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className="border-slate-200/80">
+          <CardHeader className="pb-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <CardTitle>Claims</CardTitle>
+                <CardDescription>Filter by status or search by name, email, vehicle, or claim ID.</CardDescription>
+              </div>
+            </div>
           </CardHeader>
-          <CardContent>
-            <div className="rounded-md border">
+          <CardContent className="space-y-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex w-full flex-col gap-3 sm:flex-row">
+                <div className="relative flex-1 min-w-[220px]">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    placeholder="Search by customer, email, vehicle, or ID"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    className="pl-9"
+                  />
+                </div>
+                <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as ClaimStatus | "all")}> 
+                  <SelectTrigger className="sm:w-[220px]">
+                    <Filter className="mr-2 h-4 w-4 text-slate-400" />
+                    <SelectValue placeholder="Filter by status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {statusFilters.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button
+                variant="outline"
+                className="w-full justify-center lg:w-auto"
+                onClick={() => setSortOrder((prev) => (prev === "desc" ? "asc" : "desc"))}
+              >
+                <ArrowUpDown className="mr-2 h-4 w-4" />
+                {sortOrder === "desc" ? "Newest" : "Oldest"} first
+              </Button>
+            </div>
+
+            <ScrollArea className="max-h-[540px] rounded-lg border">
               <Table>
-                <TableHeader>
+                <TableHeader className="bg-slate-50/70">
                   <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>Email</TableHead>
-                    <TableHead>Phone</TableHead>
-                    <TableHead>Message</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead>Actions</TableHead>
+                    <TableHead className="min-w-[160px]">Claimant</TableHead>
+                    <TableHead className="min-w-[160px]">Contact</TableHead>
+                    <TableHead className="min-w-[140px]">Vehicle</TableHead>
+                    <TableHead className="min-w-[220px]">Summary</TableHead>
+                    <TableHead className="min-w-[140px]">Status</TableHead>
+                    <TableHead className="min-w-[140px]">Last update</TableHead>
+                    <TableHead className="w-[90px] text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {claims.map((claim: any) => (
-                    <TableRow key={claim.id}>
-                      <TableCell>{claim.firstName} {claim.lastName}</TableCell>
-                      <TableCell>{claim.email}</TableCell>
-                      <TableCell>{claim.phone}</TableCell>
-                      <TableCell className="max-w-xs truncate">{claim.message}</TableCell>
-                      <TableCell className="capitalize">{claim.status.replace(/_/g, ' ')}</TableCell>
-                      <TableCell>{new Date(claim.createdAt).toLocaleDateString()}</TableCell>
-                      <TableCell>
-                        <Button size="sm" variant="outline" asChild>
-                          <Link href={`/admin/claims/${claim.id}`}>View</Link>
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                  {claims.length === 0 && (
+                  {filteredClaims.map((claim) => {
+                    const meta = statusMeta[claim.status];
+                    return (
+                      <TableRow key={claim.id} className="hover:bg-slate-50/70">
+                        <TableCell className="align-top">
+                          <div className="font-medium text-slate-900">{formatName(claim)}</div>
+                          <div className="text-xs text-slate-500">#{claim.id}</div>
+                        </TableCell>
+                        <TableCell className="align-top text-sm text-slate-600">
+                          <div>{claim.email || "—"}</div>
+                          <div className="text-xs text-slate-500">{claim.phone || "—"}</div>
+                        </TableCell>
+                        <TableCell className="align-top text-sm text-slate-600">{formatVehicle(claim)}</TableCell>
+                        <TableCell className="align-top text-sm text-slate-600">
+                          {claim.message ? (
+                            <span title={claim.message} className="line-clamp-2">
+                              {claim.message}
+                            </span>
+                          ) : (
+                            "—"
+                          )}
+                        </TableCell>
+                        <TableCell className="align-top">
+                          <Badge variant="outline" className={`capitalize ${meta.badgeClass}`}>
+                            {meta.label}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="align-top text-sm text-slate-600">
+                          <div>{formatDate(claim.createdAt)}</div>
+                          <div className="text-xs text-slate-500">Updated {formatDateTime(claim.updatedAt)}</div>
+                        </TableCell>
+                        <TableCell className="align-top text-right">
+                          <Button size="sm" variant="outline" asChild>
+                            <Link href={`/admin/claims/${claim.id}`}>View</Link>
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                  {filteredClaims.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={7} className="text-center py-4 text-gray-500">
-                        No claims found
+                      <TableCell colSpan={7} className="py-12 text-center text-sm text-slate-500">
+                        {searchTerm || statusFilter !== "all"
+                          ? "No claims match your filters."
+                          : "No claims have been submitted yet."}
                       </TableCell>
                     </TableRow>
                   )}
                 </TableBody>
               </Table>
-            </div>
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
           </CardContent>
         </Card>
       </div>

--- a/client/src/pages/admin/claims/[id].tsx
+++ b/client/src/pages/admin/claims/[id].tsx
@@ -1,17 +1,94 @@
-import { useState, useEffect, ChangeEvent, FormEvent } from "react";
+import { useState, useEffect, ChangeEvent, FormEvent, useMemo } from "react";
 import { useParams, Link } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import AdminNav from "@/components/admin-nav";
 import AdminLogin from "@/components/admin-login";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
+import { ArrowLeft, Clock3, FileText, Mail, Phone, ShieldCheck } from "lucide-react";
 import { clearCredentials, fetchWithAuth, getAuthHeaders } from "@/lib/auth";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
+
+type ClaimStatus =
+  | "new"
+  | "denied"
+  | "awaiting_customer_action"
+  | "awaiting_inspection"
+  | "claim_covered_open"
+  | "claim_covered_closed";
+
+const statusMeta: Record<ClaimStatus, { label: string; badgeClass: string; summary: string }> = {
+  new: {
+    label: "New",
+    badgeClass: "border-sky-200 bg-sky-50 text-sky-700",
+    summary: "Claim has been submitted and is awaiting assignment.",
+  },
+  denied: {
+    label: "Denied",
+    badgeClass: "border-rose-200 bg-rose-50 text-rose-700",
+    summary: "Customer has been notified that the claim was not covered.",
+  },
+  awaiting_customer_action: {
+    label: "Awaiting customer",
+    badgeClass: "border-amber-200 bg-amber-50 text-amber-700",
+    summary: "Waiting on documentation or follow-up from the customer.",
+  },
+  awaiting_inspection: {
+    label: "Awaiting inspection",
+    badgeClass: "border-indigo-200 bg-indigo-50 text-indigo-700",
+    summary: "Inspection appointment or diagnostics pending.",
+  },
+  claim_covered_open: {
+    label: "Covered - open",
+    badgeClass: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    summary: "Approved claim in progress with the repair facility.",
+  },
+  claim_covered_closed: {
+    label: "Covered - closed",
+    badgeClass: "border-slate-200 bg-slate-50 text-slate-600",
+    summary: "Repair is complete and the claim is fully closed.",
+  },
+};
+
+const statusOptions: { value: ClaimStatus; label: string }[] = Object.entries(statusMeta).map(([value, meta]) => ({
+  value: value as ClaimStatus,
+  label: meta.label,
+}));
+
+const formatDateTime = (value: string | null | undefined) =>
+  value
+    ? new Date(value).toLocaleString("en-US", {
+        timeZone: "America/New_York",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : "—";
+
+const formatDate = (value: string | null | undefined) =>
+  value
+    ? new Date(value).toLocaleDateString("en-US", {
+        timeZone: "America/New_York",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "—";
 
 const authJsonHeaders = () => ({
   ...getAuthHeaders(),
@@ -45,6 +122,13 @@ export default function AdminClaimDetail() {
     if (claim) setFormData(claim);
   }, [claim]);
 
+  const statusValue = useMemo<ClaimStatus>(() => {
+    const current = (formData.status ?? claim?.status) as ClaimStatus | undefined;
+    return current && current in statusMeta ? current : "new";
+  }, [claim?.status, formData.status]);
+
+  const statusDetails = statusMeta[statusValue];
+
   const updateMutation = useMutation({
     mutationFn: async (updates: any) => {
       const res = await fetchWithAuth(`/api/admin/claims/${id}`, {
@@ -74,7 +158,7 @@ export default function AdminClaimDetail() {
     setFormData((prev: any) => ({ ...prev, [name]: value }));
   };
 
-  const handleStatusChange = (value: string) => {
+  const handleStatusChange = (value: ClaimStatus) => {
     setFormData((prev: any) => ({ ...prev, status: value }));
   };
 
@@ -106,122 +190,247 @@ export default function AdminClaimDetail() {
   return (
     <div className="min-h-screen bg-gray-50">
       <AdminNav />
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
-        <Button variant="ghost" asChild>
-          <Link href="/admin/claims">&larr; Back to Claims</Link>
-        </Button>
-        <Card>
-          <CardHeader>
-            <CardTitle>Update Claim</CardTitle>
-            <CardDescription>Modify claim information</CardDescription>
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" asChild className="px-2">
+            <Link href="/admin/claims">
+              <ArrowLeft className="mr-2 h-4 w-4" /> Back to claims
+            </Link>
+          </Button>
+          <Badge variant="outline" className={`capitalize ${statusDetails?.badgeClass ?? "border-slate-200"}`}>
+            {statusDetails?.label ?? "Status"}
+          </Badge>
+          <span className="text-xs uppercase tracking-[0.32em] text-slate-400">#{claim.id}</span>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <Card className="border-slate-200/80 md:col-span-2">
+            <CardHeader className="pb-4">
+              <CardDescription>Current status</CardDescription>
+              <CardTitle className="text-xl text-slate-900">{statusDetails?.label ?? "Claim"}</CardTitle>
+              {statusDetails?.summary && (
+                <p className="text-sm text-slate-600">{statusDetails.summary}</p>
+              )}
+            </CardHeader>
+            <CardContent className="grid gap-4 sm:grid-cols-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Submitted</p>
+                <p className="mt-1 text-sm text-slate-900">{formatDate(claim.createdAt)}</p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Last updated</p>
+                <p className="mt-1 text-sm text-slate-900">{formatDateTime(claim.updatedAt)}</p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Next payment</p>
+                <p className="mt-1 text-sm text-slate-900">{formData.nextPayment || "—"}</p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="border-slate-200/80">
+            <CardHeader className="pb-3">
+              <CardDescription>Primary contact</CardDescription>
+              <CardTitle className="text-lg text-slate-900">{`${claim.firstName ?? ""} ${claim.lastName ?? ""}`.trim() || "—"}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-slate-600">
+              <div className="flex items-center gap-2">
+                <Mail className="h-4 w-4 text-slate-400" />
+                <span>{claim.email || "Not provided"}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Phone className="h-4 w-4 text-slate-400" />
+                <span>{claim.phone || "Not provided"}</span>
+              </div>
+              <Separator />
+              <div className="flex items-center gap-2">
+                <ShieldCheck className="h-4 w-4 text-slate-400" />
+                <span>{claim.policyId ? `Policy ${claim.policyId}` : "No linked policy"}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className="border-slate-200/80">
+          <CardHeader className="space-y-1">
+            <CardTitle>Claim workspace</CardTitle>
+            <CardDescription>Update status, repair milestones, contact details, and vehicle information.</CardDescription>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="grid md:grid-cols-2 gap-4">
-                <div>
-                  <Label>ID</Label>
-                  <Input value={formData.id} disabled />
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
+                <div className="space-y-6">
+                  <div className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h3 className="text-lg font-semibold text-slate-900">Status & next steps</h3>
+                        <p className="text-sm text-slate-600">Choose the current state of the claim and track upcoming actions.</p>
+                      </div>
+                      <Clock3 className="h-5 w-5 text-primary" />
+                    </div>
+                    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                      <div>
+                        <Label>Status</Label>
+                        <Select value={statusValue} onValueChange={handleStatusChange}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select status" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {statusOptions.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div>
+                        <Label htmlFor="nextEstimate">Next estimate</Label>
+                        <Input name="nextEstimate" value={formData.nextEstimate || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="nextPayment">Next payment (from policy)</Label>
+                        <Input name="nextPayment" value={formData.nextPayment || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="agentClaimNumber">Agent claim number</Label>
+                        <Input name="agentClaimNumber" value={formData.agentClaimNumber || ""} onChange={handleInputChange} />
+                      </div>
+                      <div className="sm:col-span-2">
+                        <Label htmlFor="claimReason">Claim reason</Label>
+                        <Input name="claimReason" value={formData.claimReason || ""} onChange={handleInputChange} />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h3 className="text-lg font-semibold text-slate-900">Vehicle details</h3>
+                        <p className="text-sm text-slate-600">Verify VIN, mileage, and the affected vehicle configuration.</p>
+                      </div>
+                      <FileText className="h-5 w-5 text-primary" />
+                    </div>
+                    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                      <div>
+                        <Label htmlFor="year">Year</Label>
+                        <Input name="year" value={formData.year || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="make">Make</Label>
+                        <Input name="make" value={formData.make || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="model">Model</Label>
+                        <Input name="model" value={formData.model || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="trim">Trim</Label>
+                        <Input name="trim" value={formData.trim || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="vin">VIN</Label>
+                        <Input name="vin" value={formData.vin || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="serial">Serial</Label>
+                        <Input name="serial" value={formData.serial || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="odometer">Odometer at claim</Label>
+                        <Input name="odometer" value={formData.odometer || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="currentOdometer">Current odometer</Label>
+                        <Input name="currentOdometer" value={formData.currentOdometer || ""} onChange={handleInputChange} />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm">
+                    <h3 className="text-lg font-semibold text-slate-900">Internal notes</h3>
+                    <p className="text-sm text-slate-600">Share detailed updates for teammates and future follow-ups.</p>
+                    <div className="mt-4 space-y-4">
+                      <div>
+                        <Label htmlFor="message">Claim notes</Label>
+                        <Textarea
+                          name="message"
+                          value={formData.message || ""}
+                          onChange={handleInputChange}
+                          rows={4}
+                          placeholder="Document shop conversations, approvals, or context."
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="previousNotes">Previous notes</Label>
+                        <Textarea
+                          name="previousNotes"
+                          value={formData.previousNotes || ""}
+                          onChange={handleInputChange}
+                          rows={4}
+                          placeholder="Historical notes or customer-provided updates."
+                        />
+                      </div>
+                    </div>
+                  </div>
                 </div>
-                <div>
-                  <Label>Status</Label>
-                  <Select value={formData.status} onValueChange={handleStatusChange}>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="new">New</SelectItem>
-                      <SelectItem value="denied">Denied</SelectItem>
-                      <SelectItem value="awaiting_customer_action">Awaiting Customer Action</SelectItem>
-                      <SelectItem value="awaiting_inspection">Awaiting Inspection</SelectItem>
-                      <SelectItem value="claim_covered_open">Claim Covered Open</SelectItem>
-                      <SelectItem value="claim_covered_closed">Claim Covered Closed</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label htmlFor="nextEstimate">Next Estimate</Label>
-                  <Input name="nextEstimate" value={formData.nextEstimate || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="nextPayment">Next Payment (from policy)</Label>
-                  <Input name="nextPayment" value={formData.nextPayment || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="firstName">First Name</Label>
-                  <Input name="firstName" value={formData.firstName || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="lastName">Last Name</Label>
-                  <Input name="lastName" value={formData.lastName || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="email">Email</Label>
-                  <Input name="email" value={formData.email || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="phone">Phone</Label>
-                  <Input name="phone" value={formData.phone || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="year">Year</Label>
-                  <Input name="year" value={formData.year || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="make">Make</Label>
-                  <Input name="make" value={formData.make || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="model">Model</Label>
-                  <Input name="model" value={formData.model || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="trim">Trim</Label>
-                  <Input name="trim" value={formData.trim || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="vin">VIN</Label>
-                  <Input name="vin" value={formData.vin || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="serial">Serial</Label>
-                  <Input name="serial" value={formData.serial || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="odometer">Odometer</Label>
-                  <Input name="odometer" value={formData.odometer || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="currentOdometer">Current Odometer Reading</Label>
-                  <Input name="currentOdometer" value={formData.currentOdometer || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="claimReason">Claim Reason</Label>
-                  <Input name="claimReason" value={formData.claimReason || ''} onChange={handleInputChange} />
-                </div>
-                <div>
-                  <Label htmlFor="agentClaimNumber">Agent Claim Number</Label>
-                  <Input name="agentClaimNumber" value={formData.agentClaimNumber || ''} onChange={handleInputChange} />
+
+                <div className="space-y-6">
+                  <div className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm">
+                    <h3 className="text-lg font-semibold text-slate-900">Contact information</h3>
+                    <p className="text-sm text-slate-600">Keep customer details current for outreach and status updates.</p>
+                    <div className="mt-4 grid gap-4">
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <div>
+                          <Label htmlFor="firstName">First name</Label>
+                          <Input name="firstName" value={formData.firstName || ""} onChange={handleInputChange} />
+                        </div>
+                        <div>
+                          <Label htmlFor="lastName">Last name</Label>
+                          <Input name="lastName" value={formData.lastName || ""} onChange={handleInputChange} />
+                        </div>
+                      </div>
+                      <div>
+                        <Label htmlFor="email">Email</Label>
+                        <Input name="email" value={formData.email || ""} onChange={handleInputChange} />
+                      </div>
+                      <div>
+                        <Label htmlFor="phone">Phone</Label>
+                        <Input name="phone" value={formData.phone || ""} onChange={handleInputChange} />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm">
+                    <h3 className="text-lg font-semibold text-slate-900">Audit trail</h3>
+                    <p className="text-sm text-slate-600">Reference the claim lifecycle and important identifiers.</p>
+                    <div className="mt-4 space-y-3 text-sm text-slate-600">
+                      <div className="flex items-center justify-between">
+                        <span className="text-slate-500">Claim ID</span>
+                        <span className="font-medium text-slate-900">{claim.id}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-slate-500">Submitted</span>
+                        <span className="font-medium text-slate-900">{formatDateTime(claim.createdAt)}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-slate-500">Last modified</span>
+                        <span className="font-medium text-slate-900">{formatDateTime(claim.updatedAt)}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-slate-500">Linked policy</span>
+                        <span className="font-medium text-slate-900">{claim.policyId ?? "—"}</span>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
-              <div>
-                <Label htmlFor="message">Claim Notes</Label>
-                <Textarea name="message" value={formData.message || ''} onChange={handleInputChange} />
+
+              <div className="flex items-center justify-between border-t border-slate-200/80 pt-6">
+                <p className="text-sm text-slate-500">Last saved {formatDateTime(claim.updatedAt)}</p>
+                <Button type="submit" disabled={updateMutation.isPending}>
+                  {updateMutation.isPending ? "Saving..." : "Save changes"}
+                </Button>
               </div>
-              <div>
-                <Label htmlFor="previousNotes">Previous Notes</Label>
-                <Textarea name="previousNotes" value={formData.previousNotes || ''} onChange={handleInputChange} />
-              </div>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div>
-                  <Label>Created</Label>
-                  <Input value={formData.createdAt ? new Date(formData.createdAt).toLocaleString() : ''} disabled />
-                </div>
-                <div>
-                  <Label>Modified</Label>
-                  <Input value={formData.updatedAt ? new Date(formData.updatedAt).toLocaleString() : ''} disabled />
-                </div>
-              </div>
-              <Button type="submit">Submit</Button>
             </form>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- redesign the admin claims list into a dashboard with search, filtering, and richer status styling
- add key metrics cards highlighting total, open, and attention-required claims
- overhaul the claim detail workspace with organized sections for status management, vehicle data, and notes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4321095788330a27bd43a68624274