### PR TITLE
Fix admin claims hooks ordering

### DIFF
--- a/client/src/pages/admin/claims.tsx
+++ b/client/src/pages/admin/claims.tsx
@@ -166,26 +166,6 @@ export default function AdminClaims() {
     }
   });
 
-  if (checking) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
-
-  if (!authenticated) {
-    return <AdminLogin onSuccess={markAuthenticated} />;
-  }
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
-      </div>
-    );
-  }
-
   const claims: ClaimRecord[] = data?.data || [];
 
   const { totalClaims, openClaims, attentionClaims } = useMemo(() => {
@@ -233,6 +213,26 @@ export default function AdminClaims() {
         return sortOrder === "desc" ? bTime - aTime : aTime - bTime;
       });
   }, [claims, searchTerm, statusFilter, sortOrder]);
+
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={markAuthenticated} />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50">


### PR DESCRIPTION
## Summary
- ensure memoized claim data is computed before conditional returns on the admin claims page
- prevent violating React's hook order rules that triggered the production error

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d442a4b64c8330b0725fd5571e5dc9