### PR TITLE
Prevent admin dashboard tab from being highlighted when inactive

### DIFF
--- a/client/src/components/admin-nav.tsx
+++ b/client/src/components/admin-nav.tsx
@@ -41,7 +41,8 @@ export default function AdminNav() {
           <div className="flex items-center gap-2 rounded-full bg-slate-100/80 p-1 text-sm font-medium text-slate-600 shadow-inner">
             {navItems.map(({ href, label, icon: Icon }) => {
               const isActive =
-                location === href || location.startsWith(`${href}/`);
+                location === href ||
+                (href !== "/admin" && location.startsWith(`${href}/`));
               return (
                 <Link
                   key={href}


### PR DESCRIPTION
## Summary
- ensure the admin dashboard nav item only highlights on the dashboard route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d444be08b883308017ea24a7a47809