### PR TITLE
Add admin lead deletion workflow

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3295,6 +3295,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.delete('/api/admin/leads/:id', async (req, res) => {
+    try {
+      const lead = await loadLeadFromRequest(req, res);
+      if (!lead) {
+        return;
+      }
+
+      await storage.deleteLead(lead.id);
+      delete leadMeta[lead.id];
+
+      res.json({ data: lead, message: 'Lead deleted successfully' });
+    } catch (error) {
+      console.error('Error deleting lead:', error);
+      res.status(500).json({ message: 'Failed to delete lead' });
+    }
+  });
+
   // Public claim submission endpoint
   app.post('/api/claims', async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -172,6 +172,7 @@ export interface IStorage {
   getLead(id: string): Promise<Lead | undefined>;
   createLead(lead: InsertLead & { id?: string; createdAt?: Date }): Promise<Lead>;
   updateLead(id: string, updates: Partial<InsertLead>): Promise<Lead>;
+  deleteLead(id: string): Promise<Lead | undefined>;
   
   // Vehicle operations
   getVehicleByLeadId(leadId: string): Promise<Vehicle | undefined>;
@@ -345,6 +346,11 @@ export class DatabaseStorage implements IStorage {
       .set(updates)
       .where(eq(leads.id, id))
       .returning();
+    return lead;
+  }
+
+  async deleteLead(id: string): Promise<Lead | undefined> {
+    const [lead] = await db.delete(leads).where(eq(leads.id, id)).returning();
     return lead;
   }
 


### PR DESCRIPTION
## Summary
- add a backend endpoint and storage method to delete admin leads
- clear lead metadata after deletion
- surface a delete lead action in the admin lead detail view with a confirmation dialog

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5d782d3408330b14a32b152657612