### PR TITLE
Fix email logo rendering in customer messages

### DIFF
--- a/client/public/email/bh-auto-protect-logo.svg
+++ b/client/public/email/bh-auto-protect-logo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="60%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <g fill="none" stroke="url(#g)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 70c28-28 88-48 140-48s112 20 140 48"/>
+    <path d="M28 58c18-22 78-40 132-40s114 18 132 40" opacity="0.55"/>
+  </g>
+  <g transform="translate(210 48)">
+    <path d="M36 4 18-4 0 4v32c0 18 8 34 18 42 10-8 18-24 18-42V4Z" fill="#0f172a" opacity="0.12"/>
+    <path d="M36 0 18-8 0 0v32c0 18 8 34 18 42 10-8 18-24 18-42V0Z" fill="#0b1f4e"/>
+    <path d="M9 18 18 28l15-18" stroke="#e0f2fe" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -24,6 +24,7 @@ import { fetchWithAuth, getAuthHeaders, clearCredentials } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
 import { useAdminAuth } from "@/hooks/use-admin-auth";
 import PolicyDocumentRequests from "@/components/admin-policy-document-requests";
+import { useBranding } from "@/hooks/use-branding";
 import { ArrowLeft, ChevronDown, Eye, Mail, Paperclip, PencilLine, Sparkles, ExternalLink } from "lucide-react";
 
 const CUSTOM_TEMPLATE_ID = "custom";
@@ -155,8 +156,28 @@ const escapeHtml = (value: string): string =>
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
 
-const EMAIL_BRAND_LOGO =
+const FALLBACK_EMAIL_BRAND_LOGO =
   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMjAgMTIwIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAlIiB5MT0iMCUiIHgyPSIxMDAlIiB5Mj0iMTAwJSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiMwZjE3MmEiIC8+CiAgICAgIDxzdG9wIG9mZnNldD0iNjAlIiBzdG9wLWNvbG9yPSIjMWQ0ZWQ4IiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMwZjE3MmEiIC8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogIDwvZGVmcz4KICA8ZyBmaWxsPSJub25lIiBzdHJva2U9InVybCgjZykiIHN0cm9rZS13aWR0aD0iOCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj4KICAgIDxwYXRoIGQ9Ik0yMCA3MGMyOC0yOCA4OC00OCAxNDAtNDhzMTEyIDIwIDE0MCA0OCIvPgogICAgPHBhdGggZD0iTTI4IDU4YzE4LTIyIDc4LTQwIDEzMi00MHMxMTQgMTggMTMyIDQwIiBvcGFjaXR5PSIwLjU1Ii8+CiAgPC9nPgogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIxMCA0OCkiPgogICAgPHBhdGggZD0iTTM2IDQgMTgtNCAwIDR2MzJjMCAxOCA4IDM0IDE4IDQyIDEwLTggMTgtMjQgMTgtNDJWNFoiIGZpbGw9IiMwZjE3MmEiIG9wYWNpdHk9IjAuMTIiLz4KICAgIDxwYXRoIGQ9Ik0zNiAwIDE4LTggMCAwdjMyYzAgMTggOCAzNCAxOCA0MiAxMC04IDE4LTI0IDE4LTQyVjBaIiBmaWxsPSIjMGIxZjRlIi8+CiAgICA8cGF0aCBkPSJNOSAxOCAxOCAyOGwxNS0xOCIgc3Ryb2tlPSIjZTBmMmZlIiBzdHJva2Utd2lkdGg9IjYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgogIDwvZz4KPC9zdmc+";
+
+const DEFAULT_EMAIL_LOGO_PATH = "/email/bh-auto-protect-logo.svg";
+
+const resolveEmailLogoSrc = (logoUrl: string | null | undefined): string => {
+  const candidate = logoUrl ?? DEFAULT_EMAIL_LOGO_PATH;
+  if (/^https?:\/\//i.test(candidate)) {
+    return candidate;
+  }
+  if (candidate.startsWith("data:")) {
+    return candidate;
+  }
+  if (typeof window !== "undefined") {
+    try {
+      return new URL(candidate, window.location.origin).toString();
+    } catch (error) {
+      console.warn("Unable to resolve logo URL for email templates:", error);
+    }
+  }
+  return FALLBACK_EMAIL_BRAND_LOGO;
+};
 
 const convertPlainTextToHtml = (value: string): string => {
   const paragraphs = value
@@ -320,11 +341,13 @@ const buildEmailLayout = ({
   heroTitle,
   heroSubtitle,
   bodyContent,
+  logoSrc = FALLBACK_EMAIL_BRAND_LOGO,
 }: {
   subject: string;
   heroTitle: string;
   heroSubtitle: string;
   bodyContent: string;
+  logoSrc?: string;
 }): string => `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -341,7 +364,7 @@ const buildEmailLayout = ({
             <td style="background:linear-gradient(135deg,#111827,#2563eb);padding:28px 32px;color:#ffffff;">
               <div style="display:flex;align-items:center;gap:18px;">
                 <img
-                  src="${EMAIL_BRAND_LOGO}"
+                  src="${escapeHtml(logoSrc)}"
                   alt="BHAutoProtect logo"
                   style="width:96px;height:auto;display:block;filter:drop-shadow(0 8px 18px rgba(15,23,42,0.35));"
                 />
@@ -374,10 +397,12 @@ const buildBrandedEmailFromPlainText = ({
   subject,
   message,
   policy,
+  logoSrc,
 }: {
   subject: string;
   message: string;
   policy: any;
+  logoSrc: string;
 }): string => {
   const policyPackage = formatPolicyName(policy?.package) || "Vehicle Protection";
   const heroTitle = `${policyPackage} Update`;
@@ -391,10 +416,11 @@ const buildBrandedEmailFromPlainText = ({
     heroTitle,
     heroSubtitle,
     bodyContent: finalBody,
+    logoSrc,
   });
 };
 
-const buildDefaultEmailTemplates = (policy: any): EmailTemplateRecord[] => {
+const buildDefaultEmailTemplates = (policy: any, logoSrc: string): EmailTemplateRecord[] => {
   const name = getPolicyHolderName(policy);
   const displayName = name || "there";
   const policyPackage = formatPolicyName(policy?.package) || "Vehicle Protection";
@@ -481,6 +507,7 @@ const buildDefaultEmailTemplates = (policy: any): EmailTemplateRecord[] => {
       heroTitle: `${policyPackage} Coverage Activated`,
       heroSubtitle,
       bodyContent: policyActivatedBody,
+      logoSrc,
     }),
   });
 
@@ -516,6 +543,7 @@ const buildDefaultEmailTemplates = (policy: any): EmailTemplateRecord[] => {
       heroTitle: "Account Past Due Notice",
       heroSubtitle,
       bodyContent: pastDueBody,
+      logoSrc,
     }),
   });
 
@@ -546,6 +574,7 @@ const buildDefaultEmailTemplates = (policy: any): EmailTemplateRecord[] => {
       heroTitle: "Rim & Tire Voucher Available",
       heroSubtitle,
       bodyContent: rimTireBody,
+      logoSrc,
     }),
   });
 
@@ -576,6 +605,7 @@ const buildDefaultEmailTemplates = (policy: any): EmailTemplateRecord[] => {
       heroTitle: "Maintenance Voucher Ready",
       heroSubtitle,
       bodyContent: maintenanceBody,
+      logoSrc,
     }),
   });
 
@@ -634,6 +664,9 @@ export default function AdminPolicyDetail() {
     enabled: policyQueriesEnabled,
   });
 
+  const brandingQuery = useBranding();
+  const emailLogoSrc = useMemo(() => resolveEmailLogoSrc(brandingQuery.data?.data?.logoUrl ?? null), [brandingQuery.data?.data?.logoUrl]);
+
   const {
     data: templatesResponse,
     isFetching: isFetchingTemplates,
@@ -669,7 +702,7 @@ export default function AdminPolicyDetail() {
   }, [chargesResponse]);
 
   const policyHolderName = getPolicyHolderName(policy);
-  const defaultTemplates = useMemo(() => buildDefaultEmailTemplates(policy), [policy]);
+  const defaultTemplates = useMemo(() => buildDefaultEmailTemplates(policy, emailLogoSrc), [policy, emailLogoSrc]);
   const savedTemplates = templatesResponse?.data ?? [];
 
   const primaryPaymentProfile = paymentProfiles[0] ?? null;
@@ -736,7 +769,7 @@ export default function AdminPolicyDetail() {
   }, [policy]);
 
   const buildCustomEmail = (message: string, subjectOverride?: string) =>
-    buildBrandedEmailFromPlainText({ subject: subjectOverride ?? emailSubject, message, policy });
+    buildBrandedEmailFromPlainText({ subject: subjectOverride ?? emailSubject, message, policy, logoSrc: emailLogoSrc });
 
   const syncPlainMessageFromHtml = (html: string) => {
     const stripped = stripHtmlToPlainText(html);


### PR DESCRIPTION
## Summary
- add a static BH Auto Protect SVG logo in the public assets for email use
- resolve branding logo URLs to absolute links and thread them through the admin email templates so the hosted logo appears in customer inboxes
- fall back to the hosted SVG when no custom branding logo is configured

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d65789fe0883308100d40e575a5d42