### PR TITLE
Allow edit policy dialog to scroll

### DIFF
--- a/client/src/pages/admin/policies/[id].tsx
+++ b/client/src/pages/admin/policies/[id].tsx
@@ -2050,7 +2050,7 @@ export default function AdminPolicyDetail() {
           }
         }}
       >
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit policy details</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
## Summary
- allow the edit policy dialog to scroll by capping its height within the viewport

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65bfb7e708330bb325189da4d3d23