### PR TITLE
Add branded JPEG logo to transactional emails

### DIFF
--- a/server/emailBranding.ts
+++ b/server/emailBranding.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const EMAIL_LOGO_FILENAME = "IMG_1498.jpeg";
+const EMAIL_LOGO_ALT_TEXT = "BH Auto Protect";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const emailLogoPath = path.join(__dirname, "assets", EMAIL_LOGO_FILENAME);
+
+let emailLogoDataUrl: string | null = null;
+
+try {
+  if (fs.existsSync(emailLogoPath)) {
+    const base64 = fs.readFileSync(emailLogoPath).toString("base64");
+    emailLogoDataUrl = `data:image/jpeg;base64,${base64}`;
+  } else {
+    console.warn(`Email logo asset not found at ${emailLogoPath}`);
+  }
+} catch (error) {
+  console.warn("Unable to load email logo asset:", error);
+}
+
+type RenderEmailLogoOptions = {
+  textColor?: string;
+  marginBottom?: number;
+  align?: "left" | "center" | "right";
+  height?: number;
+  maxWidth?: number;
+};
+
+export const getEmailLogoDataUrl = (): string | null => emailLogoDataUrl;
+
+export const renderEmailLogo = (options: RenderEmailLogoOptions = {}): string => {
+  const marginBottom = options.marginBottom ?? 16;
+  const align = options.align ?? "left";
+
+  if (emailLogoDataUrl) {
+    const height = options.height ?? 48;
+    const maxWidth = options.maxWidth ?? 220;
+    return `<div style="margin-bottom:${marginBottom}px;text-align:${align};"><img src="${emailLogoDataUrl}" alt="${EMAIL_LOGO_ALT_TEXT}" style="display:inline-block;height:${height}px;max-width:${maxWidth}px;width:auto;border-radius:12px;object-fit:contain;" /></div>`;
+  }
+
+  const textColor = options.textColor ?? "#ffffff";
+  return `<div style="font-size:12px;letter-spacing:0.28em;text-transform:uppercase;opacity:0.7;margin-bottom:${marginBottom}px;color:${textColor};text-align:${align};">${EMAIL_LOGO_ALT_TEXT.toUpperCase()}</div>`;
+};

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -31,6 +31,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { calculateQuote } from "../client/src/lib/pricing";
 import { verifyPassword, hashPassword } from "./password";
+import { renderEmailLogo } from "./emailBranding";
 
 type LeadMeta = {
   tags: string[];
@@ -666,7 +667,7 @@ const buildContractInviteEmail = ({
           <table role="presentation" cellpadding="0" cellspacing="0" width="640" style="width:640px;max-width:94%;background:#ffffff;border-radius:18px;overflow:hidden;box-shadow:0 22px 48px rgba(15,23,42,0.1);">
             <tr>
               <td style="background:linear-gradient(135deg,#0f172a,#2563eb);padding:32px;color:#e2e8f0;">
-                <div style="font-size:12px;letter-spacing:0.28em;text-transform:uppercase;opacity:0.7;">BH AUTO PROTECT</div>
+                ${renderEmailLogo({ textColor: '#e2e8f0' })}
                 <div style="font-size:24px;font-weight:700;margin-top:12px;">Your ${escapeHtml(planName)} contract is ready</div>
                 <div style="margin-top:8px;font-size:14px;opacity:0.85;">Quote ${escapeHtml(quote.id)} • ${escapeHtml(monthly)}</div>
               </td>
@@ -732,6 +733,7 @@ const buildContractSignedNotificationEmail = ({
           <table role="presentation" cellpadding="0" cellspacing="0" width="640" style="width:640px;max-width:94%;background:#111827;border-radius:18px;overflow:hidden;box-shadow:0 20px 45px rgba(15,23,42,0.35);">
             <tr>
               <td style="padding:30px 32px;background:linear-gradient(135deg,#1e293b,#0f172a);">
+                ${renderEmailLogo({ textColor: '#64748b' })}
                 <div style="font-size:12px;letter-spacing:0.28em;text-transform:uppercase;color:#64748b;">Contract Signed</div>
                 <div style="font-size:24px;font-weight:700;margin-top:12px;color:#e2e8f0;">${escapeHtml(customerName)} locked in coverage</div>
                 <div style="margin-top:6px;font-size:13px;color:#94a3b8;">${escapeHtml(planName)} • Lead ${escapeHtml(lead.id)}</div>
@@ -825,7 +827,7 @@ const buildDocumentRequestEmail = ({
           <table role="presentation" cellpadding="0" cellspacing="0" width="620" style="width:620px;max-width:94%;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 24px 48px rgba(15,23,42,0.08);">
             <tr>
               <td style="padding:28px 32px;background:linear-gradient(135deg,#111827,#1d4ed8);color:#ffffff;">
-                <div style="font-size:12px;letter-spacing:0.28em;text-transform:uppercase;opacity:0.7;">BHAUTOPROTECT</div>
+                ${renderEmailLogo({ textColor: '#ffffff' })}
                 <div style="margin-top:10px;font-size:22px;font-weight:600;">We need ${escapeHtml(requestLabel)}</div>
                 <div style="margin-top:6px;font-size:13px;opacity:0.8;">Policy ${escapeHtml(policyId)}</div>
               </td>
@@ -967,7 +969,7 @@ const buildQuoteEmail = ({
         <table role="presentation" cellpadding="0" cellspacing="0" width="620" style="width:620px;max-width:94%;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 20px 45px rgba(15,23,42,0.08);">
           <tr>
             <td style="background:linear-gradient(135deg,#111827,#2563eb);padding:28px 32px;color:#ffffff;">
-              <div style="font-size:12px;letter-spacing:0.28em;text-transform:uppercase;opacity:0.7;">BHAUTOPROTECT</div>
+              ${renderEmailLogo({ textColor: '#ffffff' })}
               <div style="font-size:24px;font-weight:700;margin-top:10px;">Your ${escapeHtml(planName)} Quote is Ready</div>
               <div style="margin-top:12px;font-size:14px;opacity:0.85;">Quote • ${escapeHtml(quoteId)}</div>
             </td>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -57,6 +57,7 @@ import {
 import { db } from "./db";
 import { eq, desc, sql, and, inArray } from "drizzle-orm";
 import { hashPassword } from "./password";
+import { renderEmailLogo } from "./emailBranding";
 
 const generateLeadId = () => Math.floor(10000000 + Math.random() * 90000000).toString();
 const getEasternDate = () => new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
@@ -103,7 +104,7 @@ const DEFAULT_EMAIL_TEMPLATES: { name: string; subject: string; bodyHtml: string
         <table role="presentation" cellpadding="0" cellspacing="0" width="620" style="width:620px;max-width:94%;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 20px 45px rgba(15,23,42,0.08);">
           <tr>
             <td style="background:linear-gradient(135deg,#111827,#2563eb);padding:28px 32px;color:#ffffff;">
-              <div style="font-size:12px;letter-spacing:0.28em;text-transform:uppercase;opacity:0.7;">BHAUTOPROTECT</div>
+              ${renderEmailLogo({ textColor: '#ffffff' })}
               <div style="font-size:24px;font-weight:700;margin-top:10px;">Fuel Voucher Added to Your Coverage</div>
               <div style="margin-top:12px;font-size:14px;opacity:0.85;">We're celebrating you with extra miles on us.</div>
             </td>


### PR DESCRIPTION
## Summary
- load the BH Auto Protect JPEG logo as a reusable email helper
- add the logo header to all transactional email templates
- update default seeded templates to use the shared branding helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69a525e9c8330a3ddef4c9e826127