### PR TITLE
Require customer login before submitting claims

### DIFF
--- a/client/src/pages/claims.tsx
+++ b/client/src/pages/claims.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useState } from "react";
 import Navigation from "@/components/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -6,9 +7,11 @@ import { Button } from "@/components/ui/button";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Mail, HelpCircle } from "lucide-react";
+import { Mail, HelpCircle, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { Label } from "@/components/ui/label";
+import CustomerPortalAuth from "@/pages/portal/auth";
+import { checkCustomerSession, type CustomerSessionSnapshot } from "@/lib/customer-auth";
 
 const claimFormSchema = z.object({
   firstName: z.string().min(1, "Required"),
@@ -21,6 +24,7 @@ const claimFormSchema = z.object({
 type ClaimForm = z.infer<typeof claimFormSchema>;
 
 export default function Claims() {
+  const [session, setSession] = useState<CustomerSessionSnapshot | null | undefined>(undefined);
   const { toast } = useToast();
   const form = useForm<ClaimForm>({
     resolver: zodResolver(claimFormSchema),
@@ -37,8 +41,50 @@ export default function Claims() {
     handleSubmit,
     register,
     reset,
+    setValue,
     formState: { errors, isSubmitting },
   } = form;
+
+  const fillFormFromSession = useCallback(
+    (snapshot: CustomerSessionSnapshot) => {
+      const leadWithContact = snapshot.policies.find((policy) => policy.lead)?.lead;
+      setValue("email", snapshot.customer.email, { shouldDirty: false });
+      if (leadWithContact?.firstName) {
+        setValue("firstName", leadWithContact.firstName, { shouldDirty: false });
+      }
+      if (leadWithContact?.lastName) {
+        setValue("lastName", leadWithContact.lastName, { shouldDirty: false });
+      }
+      if (leadWithContact?.phone) {
+        setValue("phone", leadWithContact.phone, { shouldDirty: false });
+      }
+    },
+    [setValue],
+  );
+
+  useEffect(() => {
+    let active = true;
+    checkCustomerSession()
+      .then((snapshot) => {
+        if (!active) return;
+        setSession(snapshot);
+        if (snapshot) {
+          fillFormFromSession(snapshot);
+        }
+      })
+      .catch(() => {
+        if (!active) return;
+        setSession(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [fillFormFromSession]);
+
+  const handleAuthenticated = (snapshot: CustomerSessionSnapshot) => {
+    setSession(snapshot);
+    fillFormFromSession(snapshot);
+  };
 
   const onSubmit = async (values: ClaimForm) => {
     try {
@@ -50,10 +96,36 @@ export default function Claims() {
       if (!res.ok) throw new Error('Failed');
       toast({ title: 'Claim submitted', description: "We'll be in touch soon." });
       reset();
+      if (session) {
+        fillFormFromSession(session);
+      }
     } catch (error) {
       toast({ title: 'Submission failed', variant: 'destructive' });
     }
   };
+
+  if (session === undefined) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Navigation onGetQuote={() => {}} />
+        <div className="flex min-h-[60vh] items-center justify-center px-4">
+          <div className="flex items-center gap-3 rounded-xl border border-dashed border-slate-300 bg-white/80 px-6 py-4 text-slate-600 shadow-sm">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            <p className="text-sm font-medium">Checking your portal access…</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-slate-950">
+        <Navigation onGetQuote={() => {}} />
+        <CustomerPortalAuth onAuthenticated={handleAuthenticated} variant="claims" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -65,39 +137,47 @@ export default function Claims() {
           <img
             src="https://images.unsplash.com/photo-1503376780353-7e6692767b70?auto=format&fit=crop&w=1500&q=80"
             alt="Road"
-            className="w-full h-64 object-cover"
+            className="h-64 w-full object-cover"
           />
           <div className="absolute inset-0 bg-primary/80" />
         </div>
-        <div className="relative h-64 flex items-center justify-center">
-          <h1 className="text-4xl font-bold text-white">CLAIMS</h1>
+        <div className="relative flex h-64 items-center justify-center">
+          <div className="text-center text-white">
+            <p className="text-sm uppercase tracking-[0.35em] text-white/70">BH Auto Protect</p>
+            <h1 className="mt-2 text-4xl font-bold">Claims center</h1>
+            <p className="mt-2 text-base font-medium text-white/80">
+              You're signed in as {session.customer.displayName || session.customer.email}. Submit your claim details below.
+            </p>
+          </div>
         </div>
       </section>
 
-      <div className="max-w-5xl mx-auto px-4 py-12 grid md:grid-cols-2 gap-8">
+      <div className="mx-auto grid max-w-5xl gap-8 px-4 py-12 md:grid-cols-2">
         {/* Left Column */}
         <div className="space-y-6">
-          <div className="flex items-start space-x-4 bg-white p-6 rounded-lg shadow-sm">
-            <div className="bg-primary/10 p-3 rounded-full">
-              <HelpCircle className="w-6 h-6 text-primary" />
+          <div className="flex items-start space-x-4 rounded-lg bg-white p-6 shadow-sm">
+            <div className="rounded-full bg-primary/10 p-3">
+              <HelpCircle className="h-6 w-6 text-primary" />
             </div>
             <div>
-              <h2 className="text-xl font-semibold mb-1">Have a Claim?</h2>
-              <p className="text-gray-600 text-sm">
-                Fill out the form and our team will reach out shortly.
+              <h2 className="text-xl font-semibold mb-1">Need to start a claim?</h2>
+              <p className="text-sm text-gray-600">
+                Share a few details and our dedicated claims team will reach out with next steps.
               </p>
             </div>
           </div>
-          <div className="flex items-start space-x-4 bg-white p-6 rounded-lg shadow-sm">
-            <div className="bg-primary/10 p-3 rounded-full">
-              <Mail className="w-6 h-6 text-primary" />
+          <div className="flex items-start space-x-4 rounded-lg bg-white p-6 shadow-sm">
+            <div className="rounded-full bg-primary/10 p-3">
+              <Mail className="h-6 w-6 text-primary" />
             </div>
             <div>
-              <h2 className="text-xl font-semibold mb-1">Email Us Directly</h2>
-              <p className="text-gray-600 text-sm">
-                <a href="mailto:claims@bhautoprotect.com" className="text-primary">
+              <h2 className="text-xl font-semibold mb-1">Prefer email?</h2>
+              <p className="text-sm text-gray-600">
+                Reach us directly at{' '}
+                <a href="mailto:claims@bhautoprotect.com" className="font-medium text-primary">
                   claims@bhautoprotect.com
                 </a>
+                {' '}and we'll respond within one business day.
               </p>
             </div>
           </div>
@@ -106,10 +186,12 @@ export default function Claims() {
         {/* Right Column */}
         <Card className="bg-white">
           <CardContent className="p-6">
-            <h2 className="text-2xl font-bold mb-2">Need Assistance?</h2>
-            <p className="text-gray-600 mb-6">Send us a message and we'll get back to you.</p>
+            <h2 className="text-2xl font-bold mb-2">Tell us what happened</h2>
+            <p className="text-gray-600 mb-6">
+              Provide as much detail as you can so we can jump in quickly and support your repair process.
+            </p>
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-              <div className="grid md:grid-cols-2 gap-4">
+              <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="firstName">First Name</Label>
                   <Input
@@ -165,7 +247,7 @@ export default function Claims() {
                 <Textarea
                   id="message"
                   rows={4}
-                  placeholder="How can we help?"
+                  placeholder="Share the incident details, timeline, and any helpful notes."
                   {...register("message")}
                 />
                 {errors.message && (
@@ -173,7 +255,7 @@ export default function Claims() {
                 )}
               </div>
               <Button type="submit" className="w-full" disabled={isSubmitting}>
-                {isSubmitting ? "Submitting..." : "SUBMIT YOUR MESSAGE"}
+                {isSubmitting ? "Submitting..." : "Submit your claim"}
               </Button>
             </form>
           </CardContent>

--- a/client/src/pages/portal/auth.tsx
+++ b/client/src/pages/portal/auth.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useMemo, useState } from "react";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -9,19 +9,42 @@ import {
   type CustomerSessionSnapshot,
 } from "@/lib/customer-auth";
 import { useToast } from "@/hooks/use-toast";
+import { KeyRound, LockKeyhole, Mail, Phone, ShieldCheck } from "lucide-react";
 
 type Props = {
   onAuthenticated: (session: CustomerSessionSnapshot) => void;
+  variant?: "portal" | "claims";
 };
 
 function isSuccess(result: AuthResult): result is Extract<AuthResult, { success: true }> {
   return result.success;
 }
 
-export default function CustomerPortalAuth({ onAuthenticated }: Props) {
+export default function CustomerPortalAuth({ onAuthenticated, variant = "portal" }: Props) {
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);
   const [loginForm, setLoginForm] = useState({ email: "", policyId: "" });
+
+  const copy = useMemo(() => {
+    if (variant === "claims") {
+      return {
+        badge: "Claims center access",
+        title: "Sign in to continue your claim",
+        description:
+          "We just need to confirm your policy details before you can submit a claim. Log in with the email on file and your policy number to move forward.",
+        formTitle: "Verify your policy",
+        buttonLabel: "Access claims form",
+      };
+    }
+    return {
+      badge: "Customer portal",
+      title: "Welcome back to BH Auto Protect",
+      description:
+        "Review your coverage, download documents, manage payments, and keep your protection on track—everything lives in one secure portal.",
+      formTitle: "Sign in to your portal",
+      buttonLabel: "Sign in",
+    };
+  }, [variant]);
 
   const handleLogin = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -41,24 +64,65 @@ export default function CustomerPortalAuth({ onAuthenticated }: Props) {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center px-4 py-16">
-      <Card className="w-full max-w-2xl shadow-2xl border-slate-700 bg-slate-900/90 backdrop-blur">
-        <CardHeader className="text-center space-y-2">
-          <CardTitle className="text-3xl font-bold text-white">BH Auto Protect Portal</CardTitle>
-          <CardDescription className="text-slate-300">
-            Access your coverage documents, submit claims, and keep your payment preferences up to date.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-6">
-            <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 text-sm text-slate-300">
-              <p className="font-semibold text-white">Already have a policy?</p>
-              <p>
-                Your customer portal account is automatically created for you. Sign in using the email on your
-                policy and the policy ID that appears on your documents.
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 px-4 py-16 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 opacity-70">
+        <div className="absolute -left-32 -top-32 h-72 w-72 rounded-full bg-primary/20 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-96 w-96 rounded-full bg-sky-500/10 blur-3xl" />
+        <div className="absolute inset-x-0 bottom-0 h-64 bg-gradient-to-t from-slate-950 via-slate-950/60" />
+      </div>
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 lg:flex-row lg:items-center">
+        <div className="space-y-8 lg:w-1/2">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-slate-200">
+            <LockKeyhole className="h-3.5 w-3.5" /> {copy.badge}
+          </span>
+          <div className="space-y-4">
+            <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">{copy.title}</h1>
+            <p className="text-base text-slate-300 sm:text-lg">{copy.description}</p>
+          </div>
+          <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200">
+            <div className="flex items-start gap-3">
+              <ShieldCheck className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary" />
+              <div>
+                <p className="font-medium">Your policy details are safe with us</p>
+                <p className="text-slate-300/80">
+                  We only use this login to match you to the right policy and protect your coverage information.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <KeyRound className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary" />
+              <div>
+                <p className="font-medium">Find your policy number quickly</p>
+                <p className="text-slate-300/80">
+                  Your policy number lives in your welcome email and on any official BH Auto Protect documents.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 rounded-xl border border-white/5 bg-slate-900/80 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Need help signing in?</p>
+              <div className="flex flex-wrap gap-4 text-sm">
+                <a className="inline-flex items-center gap-2 text-slate-200 transition hover:text-white" href="mailto:support@bhautoprotect.com">
+                  <Mail className="h-4 w-4" /> support@bhautoprotect.com
+                </a>
+                <a className="inline-flex items-center gap-2 text-slate-200 transition hover:text-white" href="tel:18005550123">
+                  <Phone className="h-4 w-4" /> 1-800-555-0123
+                </a>
+              </div>
+              <p className="text-xs text-slate-400">
+                Reach out and our support team will get you signed in or resend your policy information.
               </p>
             </div>
-            <form onSubmit={handleLogin} className="space-y-4">
+          </div>
+        </div>
+        <Card className="relative mx-auto w-full max-w-md border-slate-800/60 bg-slate-900/80 backdrop-blur-xl shadow-2xl shadow-slate-950/50">
+          <CardHeader className="space-y-1 text-left">
+            <CardTitle className="text-2xl font-semibold text-white">{copy.formTitle}</CardTitle>
+            <CardDescription className="text-sm text-slate-300">
+              Enter the email on your policy and the matching policy number to confirm your identity.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleLogin} className="space-y-5">
               <div className="space-y-2">
                 <Label className="text-slate-200" htmlFor="login-email">
                   Email
@@ -70,27 +134,38 @@ export default function CustomerPortalAuth({ onAuthenticated }: Props) {
                   placeholder="you@example.com"
                   value={loginForm.email}
                   onChange={(event) => setLoginForm({ ...loginForm, email: event.target.value })}
+                  className="border-slate-700 bg-slate-900/60 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:ring-primary"
                 />
               </div>
               <div className="space-y-2">
                 <Label className="text-slate-200" htmlFor="login-policy">
-                  Policy ID
+                  Policy number
                 </Label>
                 <Input
                   id="login-policy"
                   autoComplete="off"
-                  placeholder="Enter your policy ID"
+                  placeholder="Policy number"
                   value={loginForm.policyId}
                   onChange={(event) => setLoginForm({ ...loginForm, policyId: event.target.value })}
+                  className="border-slate-700 bg-slate-900/60 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:ring-primary"
                 />
               </div>
               <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? "Signing in..." : "Sign In"}
+                {loading ? "Checking details..." : copy.buttonLabel}
               </Button>
             </form>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-2 border-t border-slate-800/60 bg-slate-900/70 p-6 text-sm text-slate-300">
+            <p>
+              Keep an eye on your inbox—we send important coverage updates to the email tied to your policy.
+            </p>
+            <p className="text-xs text-slate-500">
+              Having trouble locating your policy number? Search your email for "BH Auto Protect" or contact our support
+              team and we'll resend your documents.
+            </p>
+          </CardFooter>
+        </Card>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- gate the public claims form behind an authenticated customer session and surface the claims-specific sign-in flow
- prefill claim contact details from the signed-in policy when available for faster submission
- redesign the customer portal sign-in page with refreshed visuals and clear support guidance for locating policy numbers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69ded72648330b3d95cb28da0517a