### PR TITLE
Add vehicle eligibility rules and not-covered flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,7 @@ import Claims from "@/pages/claims";
 import Plans from "@/pages/plans";
 import Contact from "@/pages/contact";
 import ThankYou from "@/pages/thank-you";
+import UncoveredVehicle from "@/pages/uncovered-vehicle";
 import PolicyOverview from "@/pages/policy";
 
 function Router() {
@@ -42,6 +43,7 @@ function Router() {
       <Route path="/plans" component={Plans} />
       <Route path="/contact" component={Contact} />
       <Route path="/thank-you" component={ThankYou} />
+      <Route path="/not-covered" component={UncoveredVehicle} />
       <Route path="/campaign" component={AdvertisingLanding} />
       <Route path="/promo" component={PromoPage} />
       <Route path="/legal/privacy" component={PrivacyPage} />

--- a/client/src/components/quote-form.tsx
+++ b/client/src/components/quote-form.tsx
@@ -506,7 +506,7 @@ export const QuoteForm = forwardRef<HTMLFormElement, QuoteFormProps>(
 
     const submitQuoteMutation = useMutation({
       mutationFn: async (data: QuoteData) => {
-        return apiRequest("POST", "/api/leads", {
+        const response = await apiRequest("POST", "/api/leads", {
           lead: {
             firstName: data.owner.firstName,
             lastName: data.owner.lastName,
@@ -527,19 +527,25 @@ export const QuoteForm = forwardRef<HTMLFormElement, QuoteFormProps>(
           },
           recaptchaToken,
         });
+        return response.json() as Promise<{
+          eligibility?: {
+            covered?: boolean;
+          };
+        }>;
       },
-      onSuccess: () => {
+      onSuccess: (response) => {
         if (typeof window !== "undefined") {
           window.sessionStorage.setItem(
             "lastLeadSubmission",
             JSON.stringify({
               source: leadSource,
               submittedAt: new Date().toISOString(),
+              covered: response?.eligibility?.covered !== false,
             }),
           );
         }
 
-        navigate("/thank-you");
+        navigate(response?.eligibility?.covered === false ? "/not-covered" : "/thank-you");
         onSubmitted?.();
         resetForm();
       },

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -63,6 +63,15 @@ type SampleContractResponse = {
   };
 };
 
+type VehicleEligibilityResponse = {
+  data?: {
+    excludedVehicles: Array<{ make: string; model?: string | null }>;
+    excludedStates: string[];
+    maximumMiles: number | null;
+    updatedAt?: string | null;
+  };
+};
+
 async function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -104,6 +113,11 @@ export default function AdminSettings() {
   const [quoteInstructions, setQuoteInstructions] = useState<string>(DEFAULT_INSTRUCTIONS_FALLBACK);
   const [instructionsError, setInstructionsError] = useState<string | null>(null);
   const [instructionsSuccess, setInstructionsSuccess] = useState<string | null>(null);
+  const [eligibilityVehiclesText, setEligibilityVehiclesText] = useState<string>("");
+  const [eligibilityStatesText, setEligibilityStatesText] = useState<string>("");
+  const [maximumMiles, setMaximumMiles] = useState<string>("");
+  const [eligibilityError, setEligibilityError] = useState<string | null>(null);
+  const [eligibilitySuccess, setEligibilitySuccess] = useState<string | null>(null);
 
   const queryClient = useQueryClient();
   const queriesEnabled = authenticated && !checking;
@@ -189,6 +203,37 @@ export default function AdminSettings() {
     enabled: queriesEnabled,
     staleTime: 0,
   });
+
+  const vehicleEligibilityQuery = useQuery<VehicleEligibilityResponse>({
+    queryKey: ["/api/admin/vehicle-eligibility"],
+    queryFn: async () => {
+      const response = await fetchWithAuth("/api/admin/vehicle-eligibility");
+      if (response.status === 401) {
+        clearCredentials();
+        markLoggedOut();
+        throw new Error("Unauthorized");
+      }
+      if (!response.ok) {
+        throw new Error("Failed to load vehicle eligibility settings");
+      }
+      return response.json();
+    },
+    enabled: queriesEnabled,
+    staleTime: 0,
+  });
+
+  useEffect(() => {
+    const data = vehicleEligibilityQuery.data?.data;
+    if (!data) {
+      return;
+    }
+
+    setEligibilityVehiclesText(
+      (data.excludedVehicles ?? []).map((rule) => [rule.make, rule.model].filter(Boolean).join("|")).join("\n"),
+    );
+    setEligibilityStatesText((data.excludedStates ?? []).join(", "));
+    setMaximumMiles(data.maximumMiles == null ? "" : String(data.maximumMiles));
+  }, [vehicleEligibilityQuery.data]);
 
   const uploadMutation = useMutation<BrandingUploadResponse, Error, File>({
     mutationFn: async (file: File) => {
@@ -385,6 +430,67 @@ export default function AdminSettings() {
     onError: (error) => {
       setInstructionsError(error.message);
       setInstructionsSuccess(null);
+    },
+  });
+
+
+  const saveEligibilityMutation = useMutation<VehicleEligibilityResponse, Error, void>({
+    mutationFn: async () => {
+      const excludedVehicles = eligibilityVehiclesText
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const [make, model] = line.split("|").map((part) => part.trim());
+          if (!make) {
+            throw new Error("Each excluded vehicle must include a make. Use one entry per line as Make or Make|Model.");
+          }
+          return { make, model: model || null };
+        });
+
+      const excludedStates = eligibilityStatesText
+        .split(",")
+        .map((state) => state.trim().toUpperCase())
+        .filter(Boolean);
+
+      const normalizedMaximumMiles = maximumMiles.trim();
+      const parsedMaximumMiles = normalizedMaximumMiles ? Number(normalizedMaximumMiles.replace(/,/g, "")) : null;
+
+      if (parsedMaximumMiles !== null && (!Number.isFinite(parsedMaximumMiles) || parsedMaximumMiles < 0)) {
+        throw new Error("Maximum miles must be a valid non-negative number.");
+      }
+
+      const response = await fetchWithAuth("/api/admin/vehicle-eligibility", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          excludedVehicles,
+          excludedStates,
+          maximumMiles: parsedMaximumMiles,
+        }),
+      });
+
+      if (response.status === 401) {
+        clearCredentials();
+        markLoggedOut();
+        throw new Error("Unauthorized");
+      }
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.message === "string" ? payload.message : "Failed to update vehicle eligibility settings";
+        throw new Error(message);
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/vehicle-eligibility"] });
+      setEligibilityError(null);
+      setEligibilitySuccess("Vehicle eligibility rules updated.");
+    },
+    onError: (error) => {
+      setEligibilityError(error.message);
+      setEligibilitySuccess(null);
     },
   });
 
@@ -956,6 +1062,91 @@ export default function AdminSettings() {
                   </form>
                 </>
               )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FileText className="h-5 w-5 text-primary" />
+                Vehicle Eligibility Rules
+              </CardTitle>
+              <CardDescription>
+                Configure the makes, models, states, and mileage limits that should redirect shoppers to the not-covered page.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="excluded-vehicles">Excluded makes and models</Label>
+                <Textarea
+                  id="excluded-vehicles"
+                  rows={7}
+                  value={eligibilityVehiclesText}
+                  onChange={(event) => {
+                    setEligibilityVehiclesText(event.target.value);
+                    setEligibilityError(null);
+                    setEligibilitySuccess(null);
+                  }}
+                  placeholder={"Bentley\nLand Rover|Range Rover"}
+                  disabled={saveEligibilityMutation.isPending}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Enter one rule per line. Use <span className="font-medium">Make</span> to exclude an entire make or <span className="font-medium">Make|Model</span> to exclude a specific model.
+                </p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="excluded-states">Excluded states</Label>
+                  <Input
+                    id="excluded-states"
+                    value={eligibilityStatesText}
+                    onChange={(event) => {
+                      setEligibilityStatesText(event.target.value);
+                      setEligibilityError(null);
+                      setEligibilitySuccess(null);
+                    }}
+                    placeholder="AK, HI, WA"
+                    disabled={saveEligibilityMutation.isPending}
+                  />
+                  <p className="text-xs text-muted-foreground">Use 2-letter abbreviations separated by commas.</p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="maximum-miles">Maximum miles</Label>
+                  <Input
+                    id="maximum-miles"
+                    inputMode="numeric"
+                    value={maximumMiles}
+                    onChange={(event) => {
+                      setMaximumMiles(event.target.value);
+                      setEligibilityError(null);
+                      setEligibilitySuccess(null);
+                    }}
+                    placeholder="150000"
+                    disabled={saveEligibilityMutation.isPending}
+                  />
+                  <p className="text-xs text-muted-foreground">Leave blank if mileage should not affect eligibility.</p>
+                </div>
+              </div>
+
+              {eligibilityError && (
+                <Alert variant="destructive">
+                  <AlertTitle>Save failed</AlertTitle>
+                  <AlertDescription>{eligibilityError}</AlertDescription>
+                </Alert>
+              )}
+
+              {eligibilitySuccess && (
+                <Alert>
+                  <AlertTitle>Eligibility rules updated</AlertTitle>
+                  <AlertDescription>{eligibilitySuccess}</AlertDescription>
+                </Alert>
+              )}
+
+              <Button type="button" onClick={() => saveEligibilityMutation.mutate()} disabled={saveEligibilityMutation.isPending || vehicleEligibilityQuery.isLoading}>
+                {saveEligibilityMutation.isPending ? "Saving…" : "Save eligibility rules"}
+              </Button>
             </CardContent>
           </Card>
 

--- a/client/src/pages/advertising.tsx
+++ b/client/src/pages/advertising.tsx
@@ -59,7 +59,6 @@ export default function AdvertisingLanding() {
               leadSource="landing-page"
               includeVinField
               includeZipField
-              excludedStates={["FL", "WA"]}
             />
           </div>
         </section>

--- a/client/src/pages/uncovered-vehicle.tsx
+++ b/client/src/pages/uncovered-vehicle.tsx
@@ -1,0 +1,35 @@
+import Navigation from "@/components/navigation";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle } from "lucide-react";
+
+export default function UncoveredVehicle() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-amber-50 via-white to-white flex flex-col">
+      <Navigation onGetQuote={() => {}} />
+      <main className="flex-grow flex items-center">
+        <div className="max-w-2xl mx-auto px-4 py-20">
+          <div className="bg-white rounded-xl shadow-md border border-amber-100 p-10 text-center">
+            <AlertTriangle className="w-16 h-16 text-amber-500 mx-auto mb-6" />
+            <h1 className="text-4xl font-bold text-gray-900 mb-6">
+              We&apos;re Sorry, but Your Vehicle Is Not Covered
+            </h1>
+            <p className="text-lg text-gray-700 mb-4">
+              Based on the information you provided, your vehicle does not currently qualify for coverage through our provider.
+            </p>
+            <p className="text-base text-gray-600 mb-8">
+              If you believe something was entered incorrectly, please go back and resubmit your vehicle details or contact our team for help reviewing your options.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Button asChild className="px-8 py-6 text-lg">
+                <a href="/campaign">Try again</a>
+              </Button>
+              <Button asChild variant="outline" className="px-8 py-6 text-lg">
+                <a href="/contact">Contact us</a>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -81,6 +81,26 @@ const CONVERTED_LEADS_FILE_PATH = path.join(
 const CONVERTED_STATUS_VALUES: LeadStatus[] = ['converted', 'sold'];
 const QUOTED_STATUS_VALUES: LeadStatus[] = ['quoted', 'callback'];
 const POLICY_ACTIVATION_EMAILS_ENABLED = process.env.SEND_POLICY_ACTIVATION_EMAILS === 'true';
+const VEHICLE_ELIGIBILITY_SETTING_KEY = 'vehicleEligibility.rules';
+
+const vehicleExclusionRuleSchema = z.object({
+  make: z.string().trim().min(1, 'Make is required').max(80, 'Make is too long'),
+  model: z.string().trim().max(80, 'Model is too long').optional().nullable(),
+});
+
+const vehicleEligibilitySettingsSchema = z.object({
+  excludedVehicles: z.array(vehicleExclusionRuleSchema).max(500).default([]),
+  excludedStates: z.array(z.string().trim().length(2)).max(60).default([]),
+  maximumMiles: z.number().int().min(0).max(1000000).nullable().default(null),
+});
+
+type VehicleEligibilitySettings = z.infer<typeof vehicleEligibilitySettingsSchema>;
+
+type VehicleEligibilityDecision = {
+  covered: boolean;
+  reason: 'excluded_make_model' | 'excluded_state' | 'maximum_miles' | null;
+  message: string | null;
+};
 
 const normalizeSubId = (value: unknown): string | null => {
   if (typeof value !== 'string') {
@@ -89,6 +109,100 @@ const normalizeSubId = (value: unknown): string | null => {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+};
+
+const DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS: VehicleEligibilitySettings = {
+  excludedVehicles: [],
+  excludedStates: [],
+  maximumMiles: null,
+};
+
+const normalizeEligibilityString = (value: string | null | undefined): string =>
+  (value ?? '').trim().toLowerCase();
+
+const formatEligibilitySettings = (
+  settings: VehicleEligibilitySettings,
+): VehicleEligibilitySettings => ({
+  excludedVehicles: settings.excludedVehicles.map((rule) => ({
+    make: rule.make.trim(),
+    model: rule.model?.trim() ? rule.model.trim() : null,
+  })),
+  excludedStates: settings.excludedStates
+    .map((state) => state.trim().toUpperCase())
+    .filter((state, index, values) => state.length === 2 && values.indexOf(state) === index),
+  maximumMiles:
+    typeof settings.maximumMiles === 'number' && Number.isFinite(settings.maximumMiles)
+      ? settings.maximumMiles
+      : null,
+});
+
+const loadVehicleEligibilitySettings = async (): Promise<VehicleEligibilitySettings> => {
+  const setting = await storage.getSiteSetting(VEHICLE_ELIGIBILITY_SETTING_KEY);
+  if (!setting?.value) {
+    return DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS;
+  }
+
+  try {
+    const parsed = JSON.parse(setting.value);
+    return formatEligibilitySettings(vehicleEligibilitySettingsSchema.parse(parsed));
+  } catch (error) {
+    console.error('Failed to parse vehicle eligibility settings:', error);
+    return DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS;
+  }
+};
+
+const evaluateVehicleEligibility = (
+  lead: Pick<InsertLead, 'state'>,
+  vehicle: Pick<InsertVehicle, 'make' | 'model' | 'odometer'>,
+  settings: VehicleEligibilitySettings,
+): VehicleEligibilityDecision => {
+  const normalizedState = normalizeEligibilityString(lead.state).toUpperCase();
+  if (normalizedState && settings.excludedStates.includes(normalizedState)) {
+    return {
+      covered: false,
+      reason: 'excluded_state',
+      message: `Vehicles registered in ${normalizedState} are currently not eligible for coverage.`,
+    };
+  }
+
+  const normalizedMake = normalizeEligibilityString(vehicle.make);
+  const normalizedModel = normalizeEligibilityString(vehicle.model);
+  const matchingVehicleRule = settings.excludedVehicles.find((rule) => {
+    if (normalizeEligibilityString(rule.make) !== normalizedMake) {
+      return false;
+    }
+    const normalizedRuleModel = normalizeEligibilityString(rule.model ?? '');
+    return normalizedRuleModel.length === 0 || normalizedRuleModel === normalizedModel;
+  });
+
+  if (matchingVehicleRule) {
+    return {
+      covered: false,
+      reason: 'excluded_make_model',
+      message: matchingVehicleRule.model
+        ? `${matchingVehicleRule.make} ${matchingVehicleRule.model} vehicles are currently not eligible for coverage.`
+        : `${matchingVehicleRule.make} vehicles are currently not eligible for coverage.`,
+    };
+  }
+
+  if (
+    typeof settings.maximumMiles === 'number' &&
+    Number.isFinite(settings.maximumMiles) &&
+    typeof vehicle.odometer === 'number' &&
+    vehicle.odometer > settings.maximumMiles
+  ) {
+    return {
+      covered: false,
+      reason: 'maximum_miles',
+      message: `Vehicles with more than ${settings.maximumMiles.toLocaleString('en-US')} miles are currently not eligible for coverage.`,
+    };
+  }
+
+  return {
+    covered: true,
+    reason: null,
+    message: null,
+  };
 };
 
 const ensureFileDirectory = async (filePath: string): Promise<void> => {
@@ -5917,6 +6031,53 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get('/api/admin/vehicle-eligibility', async (_req, res) => {
+    if (!ensureAdminUser(res)) {
+      return;
+    }
+
+    try {
+      const settings = await loadVehicleEligibilitySettings();
+      res.json({
+        data: settings,
+        message: 'Vehicle eligibility settings retrieved successfully',
+      });
+    } catch (error) {
+      console.error('Error loading vehicle eligibility settings:', error);
+      res.status(500).json({ message: 'Failed to load vehicle eligibility settings' });
+    }
+  });
+
+  app.post('/api/admin/vehicle-eligibility', async (req, res) => {
+    if (!ensureAdminUser(res)) {
+      return;
+    }
+
+    try {
+      const payload = formatEligibilitySettings(vehicleEligibilitySettingsSchema.parse(req.body ?? {}));
+      const saved = await storage.upsertSiteSetting({
+        key: VEHICLE_ELIGIBILITY_SETTING_KEY,
+        value: JSON.stringify(payload),
+      });
+
+      res.json({
+        data: {
+          ...payload,
+          updatedAt: toIsoString(saved.updatedAt ?? null),
+        },
+        message: 'Vehicle eligibility settings updated successfully',
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const message = error.issues.at(0)?.message ?? 'Invalid vehicle eligibility settings';
+        res.status(400).json({ message });
+        return;
+      }
+      console.error('Error updating vehicle eligibility settings:', error);
+      res.status(500).json({ message: 'Failed to update vehicle eligibility settings' });
+    }
+  });
+
   app.get('/api/admin/sample-contract', async (_req, res) => {
     if (!ensureAdminUser(res)) {
       return;
@@ -6309,6 +6470,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         delete sanitizedPayload.recaptchaToken;
       }
 
+      const eligibilitySettings = await loadVehicleEligibilitySettings();
+      const eligibilityDecision = evaluateVehicleEligibility(leadData, vehicleData, eligibilitySettings);
+
       // Create lead
       const lead = await storage.createLead(
         {
@@ -6334,6 +6498,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       res.status(201).json({
         data: lead,
+        eligibility: eligibilityDecision,
         message: 'Lead created successfully',
       });
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Provide a distinct flow for leads whose vehicle is not supported by the provider so customers are shown a friendly "not covered" page instead of the tracked thank-you page. 
- Let admins control eligibility via settings (excluded makes/models, excluded states, maximum miles) so business rules are configurable without code changes.

### Description
- Server: added site setting key `vehicleEligibility.rules`, validation schemas, `loadVehicleEligibilitySettings` and `evaluateVehicleEligibility`, plus admin endpoints `GET /api/admin/vehicle-eligibility` and `POST /api/admin/vehicle-eligibility` to read/save rules; leads creation now evaluates eligibility and includes an `eligibility` decision in the response. (see `server/routes.ts`)
- Client: Quote submission (`QuoteForm`) now reads server eligibility and redirects to `/not-covered` when `eligibility.covered === false`, otherwise to `/thank-you`, and stores a `covered` flag in session storage. (see `client/src/components/quote-form.tsx`)
- UI: added a new public page `UncoveredVehicle` at route `/not-covered` with a user-facing apology/instructions page that intentionally does not include the campaign tracking pixel. (see `client/src/pages/uncovered-vehicle.tsx` and `client/src/App.tsx` routing)
- Admin UI: added a "Vehicle Eligibility Rules" card to the Admin Settings screen allowing admins to edit excluded makes/models (one per line as `Make` or `Make|Model`), excluded 2-letter states (comma-separated), and a maximum miles value, wired to the new admin API endpoints. (see `client/src/pages/admin/settings.tsx`)
- Minor: removed the previously hard-coded excluded states from the advertising quote form so eligibility is controlled centrally in admin settings. (see `client/src/pages/advertising.tsx`)

### Testing
- Ran `git diff --check` to ensure workspace edits have no diff-check issues (passed). 
- Ran the TypeScript check via `npm run check` which failed in this environment due to missing type dependencies (`@types/node`, `vite/client`) and blocked package installation. (failed, environment limitations)
- Attempted `npm install` to run checks locally but package fetch was blocked by a network/security policy (`403 Forbidden` when fetching `docusign-esign`), preventing a full local type-check and runtime test. (failed, environment/network limitation)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baded6c4488330bdf635648122ce1e)