### PR TITLE
Campaign eligibility: add defaults (199k miles, excluded states/makes) and keep states selectable

### DIFF
--- a/client/src/components/quote-form.tsx
+++ b/client/src/components/quote-form.tsx
@@ -95,7 +95,6 @@ export const QuoteForm = forwardRef<HTMLFormElement, QuoteFormProps>(
       leadSource = "web",
       includeVinField = false,
       includeZipField = false,
-      excludedStates = [],
     },
     ref,
   ) => {
@@ -131,17 +130,7 @@ export const QuoteForm = forwardRef<HTMLFormElement, QuoteFormProps>(
     const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [pendingRecaptchaSubmit, setPendingRecaptchaSubmit] = useState(false);
 
-    const availableStates = useMemo(() => {
-      if (excludedStates.length === 0) {
-        return US_STATES;
-      }
-
-      const excludedStateSet = new Set(
-        excludedStates.map((state) => state.trim().toUpperCase()),
-      );
-
-      return US_STATES.filter((state) => !excludedStateSet.has(state.value));
-    }, [excludedStates]);
+    const availableStates = useMemo(() => US_STATES, []);
 
     useEffect(() => {
       if (typeof window === "undefined") {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -112,9 +112,17 @@ const normalizeSubId = (value: unknown): string | null => {
 };
 
 const DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS: VehicleEligibilitySettings = {
-  excludedVehicles: [],
-  excludedStates: [],
-  maximumMiles: null,
+  excludedVehicles: [
+    { make: 'Bentley', model: null },
+    { make: 'Land Rover', model: null },
+    { make: 'BMW', model: 'M3' },
+    { make: 'BMW', model: 'M4' },
+    { make: 'BMW', model: 'M5' },
+    { make: 'Mercedes-Benz', model: 'G Wagon AMG' },
+    { make: 'Nissan', model: 'Altima' },
+  ],
+  excludedStates: ['FL', 'WA', 'MO', 'CA'],
+  maximumMiles: 199000,
 };
 
 const normalizeEligibilityString = (value: string | null | undefined): string =>
@@ -122,19 +130,45 @@ const normalizeEligibilityString = (value: string | null | undefined): string =>
 
 const formatEligibilitySettings = (
   settings: VehicleEligibilitySettings,
-): VehicleEligibilitySettings => ({
-  excludedVehicles: settings.excludedVehicles.map((rule) => ({
-    make: rule.make.trim(),
-    model: rule.model?.trim() ? rule.model.trim() : null,
-  })),
-  excludedStates: settings.excludedStates
-    .map((state) => state.trim().toUpperCase())
-    .filter((state, index, values) => state.length === 2 && values.indexOf(state) === index),
-  maximumMiles:
-    typeof settings.maximumMiles === 'number' && Number.isFinite(settings.maximumMiles)
-      ? settings.maximumMiles
-      : null,
-});
+): VehicleEligibilitySettings => {
+  const excludedVehicleMap = new Map<string, { make: string; model: string | null }>();
+
+  [...DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS.excludedVehicles, ...settings.excludedVehicles].forEach((rule) => {
+    const make = rule.make.trim();
+    const model = rule.model?.trim() ? rule.model.trim() : null;
+
+    if (!make) {
+      return;
+    }
+
+    excludedVehicleMap.set(`${make.toLowerCase()}|${(model ?? '').toLowerCase()}`, {
+      make,
+      model,
+    });
+  });
+
+  const excludedStates = Array.from(
+    new Set(
+      [
+        ...DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS.excludedStates,
+        ...settings.excludedStates,
+      ]
+        .map((state) => state.trim().toUpperCase())
+        .filter((state) => state.length === 2),
+    ),
+  );
+
+  const maximumMilesCandidates = [
+    DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS.maximumMiles,
+    settings.maximumMiles,
+  ].filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+
+  return {
+    excludedVehicles: Array.from(excludedVehicleMap.values()),
+    excludedStates,
+    maximumMiles: maximumMilesCandidates.length > 0 ? Math.min(...maximumMilesCandidates) : null,
+  };
+};
 
 const loadVehicleEligibilitySettings = async (): Promise<VehicleEligibilitySettings> => {
   const setting = await storage.getSiteSetting(VEHICLE_ELIGIBILITY_SETTING_KEY);


### PR DESCRIPTION
### Motivation
- Ensure campaign submissions that exceed mileage limits, originate from specific states, or match certain makes/models are redirected to the not-covered flow.
- Preserve admin-configured eligibility while adding a set of default exclusions for campaign traffic.
- Allow the campaign form to still let shoppers select any state so excluded selections can be submitted and handled by the backend.

### Description
- Added default vehicle/make exclusions and states and a mileage cap by introducing `DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS` with `excludedVehicles` for Bentley, Land Rover, BMW M3/M4/M5, Mercedes-Benz G Wagon AMG, and Nissan Altima, `excludedStates` `['FL','WA','MO','CA']`, and `maximumMiles` set to `199000` in `server/routes.ts`.
- Updated `formatEligibilitySettings` in `server/routes.ts` to merge defaults with stored settings, dedupe excluded vehicle rules, union excluded states, and compute an effective mileage cap using the minimum of candidates so defaults are preserved and combined with admin settings.
- Kept all states selectable in the campaign quote form by changing `availableStates` to always return `US_STATES` in `client/src/components/quote-form.tsx` so excluded states remain visible and are redirected after submission by the backend eligibility check.

### Testing
- Ran `npm run check` (TypeScript check), which failed due to missing local type definition files in the environment, so full type-checking could not complete.
- Ran `npm ci` to install dependencies, which failed with a `403` fetching a dependency from the registry, preventing re-running the type check in this environment.
- Static diffs and local inspections of `server/routes.ts` and `client/src/components/quote-form.tsx` were performed to verify the intended changes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafda43ed083308de2f4273fc5bbaa)