### PR TITLE
Add Audi to default excluded vehicle eligibility list

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -113,6 +113,7 @@ const normalizeSubId = (value: unknown): string | null => {
 
 const DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS: VehicleEligibilitySettings = {
   excludedVehicles: [
+    { make: 'Audi', model: null },
     { make: 'Bentley', model: null },
     { make: 'Land Rover', model: null },
     { make: 'BMW', model: 'M3' },


### PR DESCRIPTION
### Motivation
- Treat Audi as ineligible by default so submissions for Audi from the campaign/quote flow are routed to the no-coverage page.

### Description
- Add `{ make: 'Audi', model: null }` to `DEFAULT_VEHICLE_ELIGIBILITY_SETTINGS.excludedVehicles` in `server/routes.ts`, which causes `evaluateVehicleEligibility` to mark Audi vehicles as not covered and fall back to the existing redirect to `/not-covered`.

### Testing
- Ran `npm run check`, which failed in this environment due to missing type definition files (`node` and `vite/client`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbcef29bf08330b8fff8c73ab47794)