### PR TITLE
Add partner lead webhook support and posting specs

### DIFF
--- a/docs/lead-webhook-posting-spec.md
+++ b/docs/lead-webhook-posting-spec.md
@@ -1,0 +1,88 @@
+# Lead Webhook Posting Specs
+
+Use this endpoint to send partner leads into the backend.
+
+## Endpoint
+
+- **Method:** `POST`
+- **URL:** `/webhooks/leads`
+- **Auth header:** `X-Lead-Secret: <LEAD_WEBHOOK_SECRET>`
+- **Content-Type:** `application/json`
+
+## Required partner fields
+
+These values are validated when partner payload fields are present:
+
+- `lsid` = `2959`
+- `lcid` = `11564`
+- `key` = `UL8F3w61Igfm`
+
+Additional required fields for this partner format:
+
+- `email`
+- `fname`
+- `lname`
+- `zip`
+- `homephone`
+- `model_year`
+- `make`
+- `mileage`
+- `xxTrustedFormCertUrl`
+- `ip`
+- `source_url`
+- `universal_leadid`
+
+Optional:
+
+- `subid1`, `subid2`, `subid3`
+- `model`
+
+## Field mapping in backend
+
+- `fname` → lead `firstName`
+- `lname` → lead `lastName`
+- `homephone` → lead `phone`
+- `source_url` → lead `source`
+- `subid1` (fallback to `universal_leadid`) → lead `subId`
+- `model_year` → vehicle `year`
+- `make` → vehicle `make`
+- `model` → vehicle `model`
+- `mileage` → vehicle `odometer`
+- Full request body is stored in lead `rawPayload`
+
+## Example request
+
+```bash
+curl -X POST "https://<your-domain>/webhooks/leads" \
+  -H "Content-Type: application/json" \
+  -H "X-Lead-Secret: <LEAD_WEBHOOK_SECRET>" \
+  -d '{
+    "lsid": 2959,
+    "lcid": 11564,
+    "key": "UL8F3w61Igfm",
+    "subid1": "click-123",
+    "subid2": "adgroup-a",
+    "subid3": "creative-7",
+    "email": "001@mailroot.net",
+    "fname": "admtest",
+    "lname": "admtest",
+    "zip": "92705",
+    "homephone": "3233565980",
+    "model_year": "2006",
+    "make": "Ford",
+    "model": "Escape XLT",
+    "mileage": 70000,
+    "xxTrustedFormCertUrl": "https://cert.trustedform.com/bd1234",
+    "ip": "8.8.4.4",
+    "source_url": "https://yoursite.com/form",
+    "universal_leadid": "lead-token-abc"
+  }'
+```
+
+## Response
+
+- `201` on success: `{ "ok": true, "id": "<lead_id>" }`
+- `400` for validation failures
+- `401` when `X-Lead-Secret` is missing/invalid
+- `429` for rate limiting
+- `503` when webhook is not configured (`LEAD_WEBHOOK_SECRET` missing)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1228,6 +1228,19 @@ const verifyRecaptchaToken = async (
 
 const leadWebhookPayloadSchema = z
   .object({
+    lsid: z.union([z.string(), z.number()]).optional(),
+    lcid: z.union([z.string(), z.number()]).optional(),
+    key: z.string().optional(),
+    subid1: z.string().optional(),
+    subid2: z.string().optional(),
+    subid3: z.string().optional(),
+    fname: z.string().optional(),
+    lname: z.string().optional(),
+    homephone: z.string().optional(),
+    model_year: z.union([z.string(), z.number()]).optional(),
+    xxTrustedFormCertUrl: z.string().optional(),
+    source_url: z.string().optional(),
+    universal_leadid: z.string().optional(),
     first_name: z.string().optional(),
     last_name: z.string().optional(),
     email: z.string().optional(),
@@ -6472,8 +6485,72 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const payload = leadWebhookPayloadSchema.parse(req.body ?? {});
 
+      const partnerPayloadDetected =
+        payload.lsid !== undefined ||
+        payload.lcid !== undefined ||
+        payload.key !== undefined ||
+        payload.universal_leadid !== undefined;
+
+      if (partnerPayloadDetected) {
+        const lsid = normalizeInteger(payload.lsid);
+        const lcid = normalizeInteger(payload.lcid);
+        const accessKey = normalizeString(payload.key);
+        const trustedFormUrl = normalizeString(payload.xxTrustedFormCertUrl);
+        const universalLeadId = normalizeString(payload.universal_leadid);
+        const firstName = normalizeString(payload.fname ?? payload.first_name);
+        const lastName = normalizeString(payload.lname ?? payload.last_name);
+        const partnerEmail = normalizeEmail(payload.email);
+        const partnerZip = normalizeString(payload.zip);
+        const partnerPhone = normalizeString(payload.homephone ?? payload.phone);
+        const partnerModelYear = normalizeInteger(payload.model_year ?? payload.year);
+        const partnerMake = normalizeString(payload.make);
+        const partnerMileage = normalizeInteger(payload.mileage);
+        const partnerSourceUrl = normalizeString(payload.source_url);
+        const partnerIp = normalizeString(payload.ip ?? payload.consent_ip);
+
+        if (lsid !== 2959 || lcid !== 11564 || accessKey !== "UL8F3w61Igfm") {
+          return res.status(400).json({
+            ok: false,
+            error: "Invalid partner credentials",
+          });
+        }
+
+        if (!trustedFormUrl) {
+          return res.status(400).json({
+            ok: false,
+            error: "xxTrustedFormCertUrl is required",
+          });
+        }
+
+        if (!universalLeadId) {
+          return res.status(400).json({
+            ok: false,
+            error: "universal_leadid is required",
+          });
+        }
+
+        if (
+          !partnerEmail ||
+          !firstName ||
+          !lastName ||
+          !partnerZip ||
+          !partnerPhone ||
+          partnerModelYear === undefined ||
+          !partnerMake ||
+          partnerMileage === undefined ||
+          !partnerIp ||
+          !partnerSourceUrl
+        ) {
+          return res.status(400).json({
+            ok: false,
+            error:
+              "Missing required partner fields: email, fname, lname, zip, homephone, model_year, make, mileage, ip, source_url",
+          });
+        }
+      }
+
       const email = normalizeEmail(payload.email);
-      const phone = normalizeString(payload.phone);
+      const phone = normalizeString(payload.phone ?? payload.homephone);
       if (!email && !phone) {
         console.error("Lead webhook rejected: email or phone required.");
         return res.status(400).json({ ok: false, error: "email or phone required" });
@@ -6500,11 +6577,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
         normalizeString(payload.consent_user_agent ?? payload.user_agent) ??
         normalizeString(req.get("User-Agent"));
 
-      const subId = normalizeString(payload.sub_id);
+      const subId = normalizeString(
+        payload.sub_id ?? payload.subid1 ?? payload.universal_leadid,
+      );
 
       const leadInput: Partial<InsertLead> = {
-        firstName: normalizeString(payload.first_name),
-        lastName: normalizeString(payload.last_name),
+        firstName: normalizeString(payload.first_name ?? payload.fname),
+        lastName: normalizeString(payload.last_name ?? payload.lname),
         email,
         phone,
         zip: normalizeString(payload.zip),
@@ -6513,7 +6592,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         consentTimestamp,
         consentIP,
         consentUserAgent,
-        source: normalizeString(payload.source ?? payload.lead_source),
+        source: normalizeString(
+          payload.source ?? payload.lead_source ?? payload.source_url,
+        ),
         utmSource: normalizeString(payload.utm_source),
         utmMedium: normalizeString(payload.utm_medium),
         utmCampaign: normalizeString(payload.utm_campaign),
@@ -6523,7 +6604,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         leadInput.subId = subId;
       }
 
-      const vehicleYear = normalizeInteger(payload.year);
+      const vehicleYear = normalizeInteger(payload.year ?? payload.model_year);
       const vehicleMake = normalizeString(payload.make);
       const vehicleModel = normalizeString(payload.model);
       const vehicleOdometer = normalizeInteger(payload.mileage);


### PR DESCRIPTION
### Motivation
- Accept partner-formatted leads at the existing webhook so partner traffic can be routed into the backend without requiring a separate endpoint.
- Ensure partner submissions include required credentials and proof (TrustedForm URL and universal lead id) to reduce invalid or fraudulent leads.
- Provide a short posting spec that partner/traffic teams can use to implement and test their postbacks.

### Description
- Updated `server/routes.ts` to extend `leadWebhookPayloadSchema` with partner fields including `lsid`, `lcid`, `key`, `subid1/2/3`, `fname`, `lname`, `homephone`, `model_year`, `xxTrustedFormCertUrl`, `source_url`, and `universal_leadid`.
- Added partner-detection and validation logic that checks `lsid=2959`, `lcid=11564`, `key=UL8F3w61Igfm`, enforces presence of `xxTrustedFormCertUrl` and `universal_leadid`, and requires partner fields (`email`, `fname`, `lname`, `zip`, `homephone`, `model_year`, `make`, `mileage`, `ip`, `source_url`) when partner-format payloads are detected.
- Mapped partner aliases into existing lead/vehicle fields (e.g. `fname`/`lname` → `firstName`/`lastName`, `homephone` → `phone`, `subid1`/`universal_leadid` → `subId`, `model_year` → vehicle `year`), and preserved the full request in `rawPayload`; added a new doc `docs/lead-webhook-posting-spec.md` with endpoint details and a `curl` example.

### Testing
- Ran TypeScript check with `npm run check` which attempted `tsc` and failed in this environment due to missing ambient type definitions for `node` and `vite/client` (type errors unrelated to the webhook changes).
- No other automated tests were executed in this environment; recommend running the full test/build pipeline and exercising the webhook with the `curl` example in `docs/lead-webhook-posting-spec.md` after setting `LEAD_WEBHOOK_SECRET`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59b040f2c83309c291644cad4824c)